### PR TITLE
Add project README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Medinfo
+
+FastAPI 製バックエンドと React/Vite フロントエンドからなるサンプルアプリケーションです。
+
+## 実行手順
+
+### バックエンド
+1. Python 3.10 以上をインストールします。
+2. 必要なパッケージをインストールします。
+   `pip install fastapi uvicorn[standard] sqlalchemy psycopg2-binary`
+3. 環境変数 `DATABASE_URL` に PostgreSQL の接続情報を設定します。
+   例: `export DATABASE_URL="postgresql://user:password@localhost/medinfo_db"`
+4. 下記コマンドで API サーバーを起動します。
+
+```bash
+uvicorn backend.app.main:app --reload --port 8001
+```
+
+### フロントエンド
+1. Node.js をインストールします。
+2. `cd my-medical-app` で移動し、`npm install` を実行します。
+3. 環境変数 `VITE_API_URL` にバックエンド API の URL を設定します。例: `export VITE_API_URL="http://localhost:8001"`
+4. `npm run dev` で開発サーバーを起動します。
+
+## サブディレクトリ README
+- [backend/README.md](backend/README.md)
+- [my-medical-app/README.md](my-medical-app/README.md)

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,28 @@
+# Backend - FastAPI
+
+Python 製の API サーバーです。
+
+## セットアップ
+
+1. Python 3.10 以上を準備してください。
+2. 以下のパッケージをインストールします。
+
+```bash
+pip install fastapi uvicorn[standard] sqlalchemy psycopg2-binary
+```
+
+## 環境変数
+
+PostgreSQL に接続するため `DATABASE_URL` を設定します。例:
+
+```bash
+export DATABASE_URL="postgresql://user:password@localhost/medinfo_db"
+```
+
+## サーバー起動
+
+リポジトリのルートから次のコマンドを実行します。
+
+```bash
+uvicorn backend.app.main:app --reload --port 8001
+```


### PR DESCRIPTION
## Summary
- add project overview in Japanese
- include backend and frontend run instructions with env variables
- link to subdirectory READMEs
- add backend-specific README

## Testing
- `pytest`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847af8c3ca48328851aaa446f16b8a6