### PR TITLE
Fix POST /functions schema

### DIFF
--- a/backend/app/routers/function.py
+++ b/backend/app/routers/function.py
@@ -24,7 +24,9 @@ def read_functions(skip: int = 0, limit: int = 100, db: Session = Depends(get_db
 
 # 機能マスタ新規作成（POST /functions）
 @router.post("", response_model=schemas.FunctionBase)
-def create_function(function: schemas.FunctionBase, db: Session = Depends(get_db)):
+def create_function(function: schemas.FunctionCreate, db: Session = Depends(get_db)):
+    """新しい機能マスタを登録するAPI
+    POST 時には ID を含めないため、FunctionCreate スキーマを利用する"""
     db_function = models.Function(**function.dict())
     db.add(db_function)
     db.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,6 +2,8 @@ from pydantic import BaseModel
 from typing import Optional, List
 
 class FunctionBase(BaseModel):
+    """機能マスタの基本スキーマ (読み取り用)"""
+
     id: int
     name: str
     description: Optional[str]
@@ -10,6 +12,16 @@ class FunctionBase(BaseModel):
 
     class Config:
         from_attributes = True
+
+class FunctionCreate(BaseModel):
+    """機能マスタ登録用のスキーマ
+    POST 時は自動採番されるため id フィールドは含めない"""
+
+    name: str
+    description: Optional[str] = None
+    selection_type: str
+    choices: List[str] = []
+
 
 class FacilityFunctionEntryBase(BaseModel):
     id: int

--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -495,14 +495,19 @@ export default function App() {
                 </button>
                 <button
                   onClick={() => {
-                    // 保存リクエスト
+                    // 機能マスタ登録APIへPOST
                     fetch('http://192.168.174.29:8001/functions', {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json' },
                       body: JSON.stringify({
+                        // API側はIDを要求しない
                         name: newFunctionName,
                         selection_type: newSelectionType,
-                        choices: newChoices.split(',').map(c => c.trim()).filter(c => c),
+                        // カンマ区切り文字列を配列に変換して送信
+                        choices: newChoices
+                          .split(',')
+                          .map(c => c.trim())
+                          .filter(c => c),
                       }),
                     })
                       .then((res) => res.json())


### PR DESCRIPTION
## Summary
- create `FunctionCreate` for new function registration
- use `FunctionCreate` in function router
- add explanations in code and frontend for new FunctionCreate schema

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847c22358d08328a83a9d9ce1b7f275