### PR TITLE
Implement remarks and persistent columns

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,6 +14,7 @@ class MedicalFacility(Base):
     address_detail = Column(Text)
     phone_numbers = Column(ARRAY(Text))
     fax = Column(Text)
+    remarks = Column(Text)
 
     # 関連する機能情報をリレーションで持たせる
     functions = relationship("FacilityFunctionEntry", back_populates="facility", cascade="all, delete-orphan")

--- a/backend/app/routers/facility.py
+++ b/backend/app/routers/facility.py
@@ -20,12 +20,15 @@ def get_db():
 
 # 医療機関一覧を取得（GET /facilities）
 @router.get("", response_model=List[schemas.MedicalFacility])
-def read_facilities(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+def read_facilities(skip: int = 0, limit: int | None = None, db: Session = Depends(get_db)):
     """
     医療機関情報の一覧を取得するAPI。
     ページネーションとして skip / limit を指定可能。
     """
-    facilities = db.query(models.MedicalFacility).offset(skip).limit(limit).all()
+    query = db.query(models.MedicalFacility).offset(skip)
+    if limit is not None:
+        query = query.limit(limit)
+    facilities = query.all()
     return facilities
 
 # 医療機関を新規登録（POST /facilities）

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -40,6 +40,7 @@ class MedicalFacilityBase(BaseModel):
     address_detail: Optional[str]
     phone_numbers: Optional[List[str]]
     fax: Optional[str]
+    remarks: Optional[str]
 
 class MedicalFacility(MedicalFacilityBase):
     id: int
@@ -56,6 +57,7 @@ class MedicalFacilityUpdate(BaseModel):
     address_detail: Optional[str] = None
     phone_numbers: Optional[List[str]] = None
     fax: Optional[str] = None
+    remarks: Optional[str] = None
 
 class FacilityFunctionEntryCreate(BaseModel):
     facility_id: int


### PR DESCRIPTION
## Summary
- add remarks column to `MedicalFacility`
- return unlimited records by default in `read_facilities`
- handle facility remarks in API schemas
- persist visible columns with cookies and refresh screen when adding function masters
- allow newline-separated function choices

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685e40b631f08328975f08b595085081