### PR TITLE
Add scripts for DB reset and CSV import

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -26,3 +26,19 @@ export DATABASE_URL="postgresql://user:password@localhost/medinfo_db"
 ```bash
 uvicorn backend.app.main:app --reload --port 8001
 ```
+
+## DB のリセット
+
+すべてのテーブルを削除して作成し直すには次のコマンドを使います。
+
+```bash
+python backend/app/reset_db.py
+```
+
+## CSV からの医療機関一括登録
+
+カンマ区切りの CSV を読み込み医療機関を追加登録できます。電話番号を複数登録したい場合は `phone_numbers` 列で `|` で区切ってください。
+
+```bash
+python backend/app/import_facilities_csv.py path/to/facilities.csv
+```

--- a/backend/app/import_facilities_csv.py
+++ b/backend/app/import_facilities_csv.py
@@ -1,0 +1,41 @@
+import csv
+import sys
+
+from .database import SessionLocal
+from .models import MedicalFacility
+
+
+def import_from_csv(csv_path: str) -> None:
+    session = SessionLocal()
+    created = 0
+    try:
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                facility = MedicalFacility(
+                    short_name=row.get("short_name", ""),
+                    official_name=row.get("official_name"),
+                    prefecture=row.get("prefecture"),
+                    city=row.get("city"),
+                    address_detail=row.get("address_detail"),
+                    phone_numbers=row.get("phone_numbers").split("|") if row.get("phone_numbers") else None,
+                    fax=row.get("fax"),
+                    remarks=row.get("remarks"),
+                )
+                session.add(facility)
+                created += 1
+        session.commit()
+        print(f"Imported {created} facilities")
+    finally:
+        session.close()
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python import_facilities_csv.py <csv_file>")
+        sys.exit(1)
+    import_from_csv(sys.argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/reset_db.py
+++ b/backend/app/reset_db.py
@@ -1,0 +1,12 @@
+from .database import Base, engine
+
+
+def reset_db():
+    """Drop all tables and recreate them."""
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    print("Database reset completed.")
+
+
+if __name__ == "__main__":
+    reset_db()


### PR DESCRIPTION
## Summary
- add a script to drop and recreate all tables
- add a script to import medical facilities from a CSV
- document the new scripts in `backend/README.md`

## Testing
- `python -m py_compile backend/app/reset_db.py backend/app/import_facilities_csv.py`
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68633b337a488328a68d716582bf7476