### PR TITLE
Fix instructions for maintenance scripts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -29,10 +29,10 @@ uvicorn backend.app.main:app --reload --port 8001
 
 ## DB のリセット
 
-すべてのテーブルを削除して作成し直すには次のコマンドを使います。
+すべてのテーブルを削除して作成し直すには次のコマンドを使います。リポジトリのルートで実行してください。
 
 ```bash
-python backend/app/reset_db.py
+python -m backend.app.reset_db
 ```
 
 ## CSV からの医療機関一括登録
@@ -40,9 +40,8 @@ python backend/app/reset_db.py
 カンマ区切りの CSV を読み込み医療機関を追加登録できます。電話番号を複数登録したい場合は `phone_numbers` 列で `|` で区切ってください。
 
 ```bash
-python backend/app/import_facilities_csv.py path/to/facilities.csv
+python -m backend.app.import_facilities_csv path/to/facilities.csv
 ```
 
 サンプルとして `backend/facilities_sample.csv` を用意しています。
-=======
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,9 +1,10 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 # DB接続情報（ユーザー: orca / パスワード: orca）
-DATABASE_URL = "postgresql://orca:orca@localhost/medinfo_db"
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://orca:orca@localhost/medinfo_db")
 
 # SQLAlchemyエンジン生成
 engine = create_engine(DATABASE_URL)

--- a/backend/app/reset_db.py
+++ b/backend/app/reset_db.py
@@ -1,4 +1,5 @@
 from .database import Base, engine
+from . import models  # ensure models are registered with Base
 
 
 def reset_db():


### PR DESCRIPTION
## Summary
- fix backend README instructions so scripts run as modules
- remove stray `=======` line
- support `DATABASE_URL` env var in database module
- import models in reset_db

## Testing
- `pytest -q`
- `python -m backend.app.reset_db` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68635920a17c8328be514675933e76a1