### PR TITLE
Add edit and logical delete for function master

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, ARRAY, CheckConstraint
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, ARRAY, CheckConstraint, Boolean
 from sqlalchemy.orm import relationship
 from .database import Base
 
@@ -28,6 +28,7 @@ class Function(Base):
     description = Column(Text)
     selection_type = Column(Text, CheckConstraint("selection_type IN ('single', 'multiple')"))
     choices = Column(ARRAY(Text))
+    is_deleted = Column(Boolean, default=False)
 
     # 機能エントリ（中間テーブル）側からの逆参照
     entries = relationship("FacilityFunctionEntry", back_populates="function", cascade="all, delete-orphan")

--- a/backend/app/routers/function.py
+++ b/backend/app/routers/function.py
@@ -19,7 +19,13 @@ def get_db():
 # 機能マスタ一覧取得（GET /functions）
 @router.get("", response_model=List[schemas.FunctionBase])
 def read_functions(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
-    functions = db.query(models.Function).offset(skip).limit(limit).all()
+    functions = (
+        db.query(models.Function)
+        .filter(models.Function.is_deleted == False)
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
     return functions
 
 # 機能マスタ新規作成（POST /functions）
@@ -40,7 +46,11 @@ def update_function(function_id: int, update_data: schemas.FunctionUpdate, db: S
     機能マスタ情報を更新するAPI。
     部分更新対応。対象がなければ404。
     """
-    db_function = db.query(models.Function).filter(models.Function.id == function_id).first()
+    db_function = (
+        db.query(models.Function)
+        .filter(models.Function.id == function_id, models.Function.is_deleted == False)
+        .first()
+    )
     if not db_function:
         raise HTTPException(status_code=404, detail="Function not found")
     
@@ -60,10 +70,14 @@ def delete_function(function_id: int, db: Session = Depends(get_db)):
     機能マスタ情報を削除するAPI。
     削除対象が見つからない場合は404。
     """
-    db_function = db.query(models.Function).filter(models.Function.id == function_id).first()
+    db_function = (
+        db.query(models.Function)
+        .filter(models.Function.id == function_id, models.Function.is_deleted == False)
+        .first()
+    )
     if not db_function:
         raise HTTPException(status_code=404, detail="Function not found")
     
-    db.delete(db_function)
+    db_function.is_deleted = True
     db.commit()
     return {"message": "Function deleted successfully"}


### PR DESCRIPTION
## Summary
- add `is_deleted` column to function master
- filter out logically deleted functions when listing
- mark functions deleted on DELETE
- refresh data and support editing/deleting function master in frontend
- add lint fixes

## Testing
- `npm run lint`
- `python -m backend.app.reset_db` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68636355d53883289f7d74dfaf1c1c30