### PR TITLE
Implement contacts, sorting states and CSV export

### DIFF
--- a/backend/app/import_facilities_csv.py
+++ b/backend/app/import_facilities_csv.py
@@ -18,7 +18,14 @@ def import_from_csv(csv_path: str) -> None:
                     prefecture=row.get("prefecture"),
                     city=row.get("city"),
                     address_detail=row.get("address_detail"),
-                    phone_numbers=row.get("phone_numbers").split("|") if row.get("phone_numbers") else None,
+                    phone_numbers=[
+                        {"value": p.split(":")[0], "comment": p.split(":")[1] if ":" in p else ""}
+                        for p in row.get("phone_numbers", "").split("|") if p
+                    ] or None,
+                    emails=[
+                        {"value": e.split(":")[0], "comment": e.split(":")[1] if ":" in e else ""}
+                        for e in row.get("emails", "").split("|") if e
+                    ] or None,
                     fax=row.get("fax"),
                     remarks=row.get("remarks"),
                 )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, ARRAY, CheckConstraint, Boolean
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, ARRAY, CheckConstraint, Boolean, JSON
 from sqlalchemy.orm import relationship
 from .database import Base
 
@@ -12,7 +12,8 @@ class MedicalFacility(Base):
     prefecture = Column(Text)
     city = Column(Text)
     address_detail = Column(Text)
-    phone_numbers = Column(ARRAY(Text))
+    phone_numbers = Column(JSON)
+    emails = Column(JSON)
     fax = Column(Text)
     remarks = Column(Text)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,11 @@
 from pydantic import BaseModel
 from typing import Optional, List
 
+
+class ContactInfo(BaseModel):
+    value: str
+    comment: Optional[str] = None
+
 class FunctionBase(BaseModel):
     """機能マスタの基本スキーマ (読み取り用)"""
 
@@ -38,7 +43,8 @@ class MedicalFacilityBase(BaseModel):
     prefecture: Optional[str]
     city: Optional[str]
     address_detail: Optional[str]
-    phone_numbers: Optional[List[str]]
+    phone_numbers: Optional[List[ContactInfo]]
+    emails: Optional[List[ContactInfo]]
     fax: Optional[str]
     remarks: Optional[str]
 
@@ -55,7 +61,8 @@ class MedicalFacilityUpdate(BaseModel):
     prefecture: Optional[str] = None
     city: Optional[str] = None
     address_detail: Optional[str] = None
-    phone_numbers: Optional[List[str]] = None
+    phone_numbers: Optional[List[ContactInfo]] = None
+    emails: Optional[List[ContactInfo]] = None
     fax: Optional[str] = None
     remarks: Optional[str] = None
 


### PR DESCRIPTION
## Summary
- support phone and email contacts with comments on facility model
- extend sorting logic to include an unsorted state
- show facility name in function edit modal
- enlarge choice text area in function master modal
- allow multiple phone numbers and emails with comments
- add CSV export of current view preserving leading zeros

## Testing
- `npm run lint`
- `python -m py_compile backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68636b42d7648328a2da2bcc4ea5711d