### PR TITLE
Add memo support and facility delete

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -16,6 +16,7 @@ class MedicalFacility(Base):
     emails = Column(JSON)
     fax = Column(Text)
     remarks = Column(Text)
+    is_deleted = Column(Boolean, default=False)
 
     # 関連する機能情報をリレーションで持たせる
     functions = relationship("FacilityFunctionEntry", back_populates="facility", cascade="all, delete-orphan")
@@ -27,6 +28,7 @@ class Function(Base):
     id = Column(Integer, primary_key=True)
     name = Column(Text, nullable=False)
     description = Column(Text)
+    memo = Column(Text)
     selection_type = Column(Text, CheckConstraint("selection_type IN ('single', 'multiple')"))
     choices = Column(ARRAY(Text))
     is_deleted = Column(Boolean, default=False)

--- a/backend/app/routers/facility.py
+++ b/backend/app/routers/facility.py
@@ -25,7 +25,11 @@ def read_facilities(skip: int = 0, limit: int | None = None, db: Session = Depen
     医療機関情報の一覧を取得するAPI。
     ページネーションとして skip / limit を指定可能。
     """
-    query = db.query(models.MedicalFacility).offset(skip)
+    query = (
+        db.query(models.MedicalFacility)
+        .filter(models.MedicalFacility.is_deleted == False)
+        .offset(skip)
+    )
     if limit is not None:
         query = query.limit(limit)
     facilities = query.all()
@@ -77,6 +81,6 @@ def delete_facility(facility_id: int, db: Session = Depends(get_db)):
     if not db_facility:
         raise HTTPException(status_code=404, detail="Facility not found")
 
-    db.delete(db_facility)
+    db_facility.is_deleted = True
     db.commit()
     return {"message": "Facility deleted successfully"}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -12,6 +12,7 @@ class FunctionBase(BaseModel):
     id: int
     name: str
     description: Optional[str]
+    memo: Optional[str]
     selection_type: str
     choices: List[str]
 
@@ -24,6 +25,7 @@ class FunctionCreate(BaseModel):
 
     name: str
     description: Optional[str] = None
+    memo: Optional[str] = None
     selection_type: str
     choices: List[str] = []
 
@@ -79,6 +81,7 @@ class FunctionUpdate(BaseModel):
     """
     name: Optional[str] = None
     description: Optional[str] = None
+    memo: Optional[str] = None
     selection_type: Optional[str] = None
     choices: Optional[List[str]] = None
 


### PR DESCRIPTION
## Summary
- support memo field for function master
- filter logically deleted facilities and add facility delete endpoint
- show function memos as tooltip
- add hamburger menu for toolbar
- display contact info and remarks vertically
- add facility delete button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863a3b55aec832884cfc8b63a4779cd