### PR TITLE
Adjust menu layout and page padding

### DIFF
--- a/my-medical-app/src/App.css
+++ b/my-medical-app/src/App.css
@@ -1,7 +1,7 @@
 #root {
   width: 100%;
   margin: 0;
-  padding: 2rem;
+  padding: 0;
 }
 
 .logo {

--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -543,7 +543,7 @@ export default function App() {
   );
 
   return (
-    <div className="bg-gray-100 min-h-screen p-4">
+    <div className="bg-gray-100 min-h-screen p-0">
       <div className="flex items-center mb-4">
         <h1 className="text-2xl font-bold">医療機関一覧</h1>
         <div className="relative ml-4">
@@ -554,7 +554,7 @@ export default function App() {
             &#9776;
           </button>
           {isMenuOpen && (
-            <div className="absolute mt-2 bg-white border rounded shadow flex flex-col space-y-2">
+            <div className="absolute mt-2 bg-white border rounded shadow flex space-x-2">
               <button
                 onClick={() => {
                   setIsColumnModalOpen(true);


### PR DESCRIPTION
## Summary
- remove padding from `#root`
- display hamburger menu items horizontally
- remove page padding around medical institution list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68648f3375d48328ba39005d2c82c0e7