### PR TITLE
Fix hamburger menu width

### DIFF
--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -554,7 +554,7 @@ export default function App() {
             &#9776;
           </button>
           {isMenuOpen && (
-            <div className="absolute mt-2 bg-white border rounded shadow flex flex-col space-y-2">
+            <div className="absolute mt-2 bg-white border rounded shadow flex flex-col space-y-2 w-max">
               <button
                 onClick={() => {
                   setIsColumnModalOpen(true);


### PR DESCRIPTION
## Summary
- ensure hamburger menu items don't wrap by adding `w-max` to the dropdown container

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864a075a9b0832890bafc9e3b9790c0