### PR TITLE
Add SQL schema

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from .database import Base, engine
-from .routers import facility, function, facility_function_entry
+from .routers import facility, function, facility_function_entry, function_category
 from fastapi.middleware.cors import CORSMiddleware
 
 # DB初期化（テーブル作成）
@@ -21,3 +21,4 @@ app.add_middleware(
 app.include_router(facility.router)
 app.include_router(function.router)
 app.include_router(facility_function_entry.router)
+app.include_router(function_category.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,6 +2,16 @@ from sqlalchemy import Column, Integer, String, Text, ForeignKey, ARRAY, CheckCo
 from sqlalchemy.orm import relationship
 from .database import Base
 
+# 機能カテゴリテーブル
+class FunctionCategory(Base):
+    __tablename__ = "function_categories"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(Text, nullable=False)
+    description = Column(Text)
+
+    functions = relationship("Function", back_populates="category")
+
 # 医療機関テーブル
 class MedicalFacility(Base):
     __tablename__ = "medical_facility"
@@ -31,8 +41,10 @@ class Function(Base):
     memo = Column(Text)
     selection_type = Column(Text, CheckConstraint("selection_type IN ('single', 'multiple')"))
     choices = Column(ARRAY(Text))
+    category_id = Column(Integer, ForeignKey("function_categories.id"))
     is_deleted = Column(Boolean, default=False)
 
+    category = relationship("FunctionCategory", back_populates="functions")
     # 機能エントリ（中間テーブル）側からの逆参照
     entries = relationship("FacilityFunctionEntry", back_populates="function", cascade="all, delete-orphan")
 

--- a/backend/app/routers/function_category.py
+++ b/backend/app/routers/function_category.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+from .. import database, models, schemas
+
+router = APIRouter(prefix="/function-categories", tags=["function_categories"])
+
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("", response_model=List[schemas.FunctionCategoryBase])
+def read_categories(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(models.FunctionCategory).offset(skip).limit(limit).all()
+
+
+@router.post("", response_model=schemas.FunctionCategoryBase)
+def create_category(category: schemas.FunctionCategoryCreate, db: Session = Depends(get_db)):
+    db_cat = models.FunctionCategory(**category.dict())
+    db.add(db_cat)
+    db.commit()
+    db.refresh(db_cat)
+    return db_cat
+
+
+@router.put("/{category_id}", response_model=schemas.FunctionCategoryBase)
+def update_category(category_id: int, update_data: schemas.FunctionCategoryUpdate, db: Session = Depends(get_db)):
+    db_cat = db.query(models.FunctionCategory).filter(models.FunctionCategory.id == category_id).first()
+    if not db_cat:
+        raise HTTPException(status_code=404, detail="Category not found")
+    for key, value in update_data.dict(exclude_unset=True).items():
+        setattr(db_cat, key, value)
+    db.commit()
+    db.refresh(db_cat)
+    return db_cat
+
+
+@router.delete("/{category_id}", response_model=dict)
+def delete_category(category_id: int, db: Session = Depends(get_db)):
+    db_cat = db.query(models.FunctionCategory).filter(models.FunctionCategory.id == category_id).first()
+    if not db_cat:
+        raise HTTPException(status_code=404, detail="Category not found")
+    db.delete(db_cat)
+    db.commit()
+    return {"message": "Category deleted"}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -6,6 +6,15 @@ class ContactInfo(BaseModel):
     value: str
     comment: Optional[str] = None
 
+class FunctionCategoryBase(BaseModel):
+    id: int
+    name: str
+    description: Optional[str]
+
+    class Config:
+        from_attributes = True
+
+
 class FunctionBase(BaseModel):
     """機能マスタの基本スキーマ (読み取り用)"""
 
@@ -15,6 +24,7 @@ class FunctionBase(BaseModel):
     memo: Optional[str]
     selection_type: str
     choices: List[str]
+    category_id: Optional[int]
 
     class Config:
         from_attributes = True
@@ -28,6 +38,7 @@ class FunctionCreate(BaseModel):
     memo: Optional[str] = None
     selection_type: str
     choices: List[str] = []
+    category_id: Optional[int] = None
 
 
 class FacilityFunctionEntryBase(BaseModel):
@@ -84,6 +95,7 @@ class FunctionUpdate(BaseModel):
     memo: Optional[str] = None
     selection_type: Optional[str] = None
     choices: Optional[List[str]] = None
+    category_id: Optional[int] = None
 
 class FacilityFunctionEntryUpdate(BaseModel):
     """
@@ -94,4 +106,14 @@ class FacilityFunctionEntryUpdate(BaseModel):
     function_id: Optional[int] = None
     selected_values: Optional[List[str]] = None
     remarks: Optional[str] = None
+
+
+class FunctionCategoryCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+
+
+class FunctionCategoryUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
 

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -1,0 +1,45 @@
+-- PostgreSQL schema for Medinfo
+
+CREATE TABLE medical_facility (
+    id SERIAL PRIMARY KEY,
+    short_name TEXT NOT NULL,
+    official_name TEXT,
+    prefecture TEXT,
+    city TEXT,
+    address_detail TEXT,
+    phone_numbers JSONB,
+    emails JSONB,
+    fax TEXT,
+    remarks TEXT,
+    is_deleted BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE function_categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE functions (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    memo TEXT,
+    selection_type TEXT CHECK (selection_type IN ('single', 'multiple')),
+    choices TEXT[],
+    category_id INTEGER REFERENCES function_categories(id),
+    is_deleted BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE facility_function_entries (
+    id SERIAL PRIMARY KEY,
+    facility_id INTEGER REFERENCES medical_facility(id),
+    function_id INTEGER REFERENCES functions(id),
+    selected_values TEXT[],
+    remarks TEXT
+);
+
+INSERT INTO function_categories (name, description) VALUES
+    ('基本機能', '一般的な機能をまとめたカテゴリ'),
+    ('設備', '施設の設備に関する機能'),
+    ('サービス', '提供サービスに関する機能');


### PR DESCRIPTION
## Summary
- include SQL script creating database tables and inserting initial categories
- centralizes backend base URL using `VITE_API_URL` and shows notifications on API errors
- add function categories with CRUD API and front-end management
- allow assigning categories when editing function master

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865bd615bf483289a34392501298ca1