### PR TITLE
Fix clearing of function category

### DIFF
--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -604,7 +604,8 @@ export default function App() {
         .map((c) => c.trim())
         .filter((c) => c),
       memo: newMemo || undefined,
-      category_id: newFunctionCategoryId || undefined,
+      // category_id は null を明示的に送信して未選択状態に戻せるようにする
+      category_id: newFunctionCategoryId,
     };
     const url = editingFunctionMaster
       ? `${apiBase}/functions/${editingFunctionMaster.id}`


### PR DESCRIPTION
## Summary
- ensure Function Master can set category back to "unselected"

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866414a78248328928b203728370fc7