### PR TITLE
Enable clicking category headers to collapse

### DIFF
--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -959,7 +959,12 @@ export default function App() {
                 if (colsInGroup.length === 0) return null;
                 const span = collapsedGroups[g.id] ? 1 : colsInGroup.length;
                 return (
-                  <th key={g.id} colSpan={span} className="border px-2">
+                  <th
+                    key={g.id}
+                    colSpan={span}
+                    className="border px-2 cursor-pointer"
+                    onClick={() => toggleCollapse(g.id)}
+                  >
                     <div className="flex items-center justify-between">
                       <span>{g.label}</span>
                       <button


### PR DESCRIPTION
## Summary
- allow toggling a header group by clicking anywhere on the header cell

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68673d86cff48328abfcd42137df38f6