### PR TITLE
Hide deleted functions

### DIFF
--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -410,14 +410,17 @@ export default function App() {
   };
 
   const hasUncategorizedColumn = allFunctions.some(
-    (f) => f.category_id === null,
+    (f) => !f.is_deleted && f.category_id === null,
   );
 
   const columnGroups = [
     { id: 'facility', label: '医療機関情報' },
     ...categoryOrder
       .map((id) => allCategories.find((c) => c.id === id))
-      .filter((c): c is FunctionCategory => !!c)
+      .filter(
+        (c): c is FunctionCategory =>
+          !!c && (showDeletedCategories || !c.is_deleted)
+      )
       .map((cat) => ({ id: `cat_${cat.id}`, label: cat.name })),
     ...(hasUncategorizedColumn ? [{ id: 'cat_null', label: '未選択' }] : []),
   ];
@@ -435,7 +438,9 @@ export default function App() {
     { key: 'remarks', label: '備考', group: 'facility' },
     ...functionOrder
       .map((id: number) => allFunctions.find((f) => f.id === id))
-      .filter((f): f is FunctionMaster => !!f)
+      .filter(
+        (f): f is FunctionMaster => !!f && (showDeletedFunctions || !f.is_deleted)
+      )
       .map((func) => ({
         key: `func_${func.id}`,
         label: func.name,


### PR DESCRIPTION
## Summary
- filter deleted categories and functions from table view
- avoid counting deleted functions when checking for uncategorized columns

## Testing
- `npm run lint --prefix my-medical-app`
- `npm run build --prefix my-medical-app`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6867536d96808328bf6fad72d3b80b12