### PR TITLE
Prevent blank names

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from typing import Optional, List
 
 
@@ -42,6 +42,12 @@ class FunctionCreate(BaseModel):
     choices: List[str] = []
     category_id: Optional[int] = None
 
+    @validator("name")
+    def validate_name(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("名称が未入力のため登録できません")
+        return v
+
 
 class FacilityFunctionEntryBase(BaseModel):
     id: int
@@ -63,6 +69,12 @@ class MedicalFacilityBase(BaseModel):
     fax: Optional[str]
     remarks: Optional[str]
 
+    @validator("short_name")
+    def validate_short_name(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("略名が未入力のため登録できません")
+        return v
+
 class MedicalFacility(MedicalFacilityBase):
     id: int
     functions: List[FacilityFunctionEntryBase] = []
@@ -80,6 +92,12 @@ class MedicalFacilityUpdate(BaseModel):
     emails: Optional[List[ContactInfo]] = None
     fax: Optional[str] = None
     remarks: Optional[str] = None
+
+    @validator("short_name")
+    def validate_short_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.strip():
+            raise ValueError("略名が未入力のため登録できません")
+        return v
 
 class FacilityFunctionEntryCreate(BaseModel):
     facility_id: int
@@ -99,6 +117,12 @@ class FunctionUpdate(BaseModel):
     choices: Optional[List[str]] = None
     category_id: Optional[int] = None
 
+    @validator("name")
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.strip():
+            raise ValueError("名称が未入力のため登録できません")
+        return v
+
 class FacilityFunctionEntryUpdate(BaseModel):
     """
     施設機能割り当て情報の更新用スキーマ。
@@ -114,8 +138,20 @@ class FunctionCategoryCreate(BaseModel):
     name: str
     description: Optional[str] = None
 
+    @validator("name")
+    def validate_name(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("カテゴリ名が未入力のため登録できません")
+        return v
+
 
 class FunctionCategoryUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
+
+    @validator("name")
+    def validate_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.strip():
+            raise ValueError("カテゴリ名が未入力のため登録できません")
+        return v
 

--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -562,15 +562,24 @@ export default function App() {
           });
 
     request
-      .then((res) => res.json())
+      .then(async (res) => {
+        const data = await res.json();
+        if (!res.ok) {
+          showError(data.detail ?? '保存に失敗しました');
+          throw new Error('save failed');
+        }
+        return data;
+      })
       .then(() => {
         setIsFacilityModalOpen(false);
         setEditingFacility(null);
         fetchFacilities();
       })
       .catch((err) => {
-        console.error('保存エラー:', err);
-        showError('保存に失敗しました');
+        if (err.message !== 'save failed') {
+          console.error('保存エラー:', err);
+          showError('保存に失敗しました');
+        }
       });
   };
 
@@ -675,7 +684,14 @@ export default function App() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     })
-      .then((res) => res.json())
+      .then(async (res) => {
+        const data = await res.json();
+        if (!res.ok) {
+          showError(data.detail ?? '保存に失敗しました');
+          throw new Error('save failed');
+        }
+        return data;
+      })
       .then(() => {
         setIsFunctionMasterModalOpen(false);
         setEditingFunctionMaster(null);
@@ -686,8 +702,10 @@ export default function App() {
         refreshData();
       })
       .catch((err) => {
-        console.error('保存エラー:', err);
-        showError('保存に失敗しました');
+        if (err.message !== 'save failed') {
+          console.error('保存エラー:', err);
+          showError('保存に失敗しました');
+        }
       });
   };
 
@@ -740,7 +758,14 @@ export default function App() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     })
-      .then((res) => res.json())
+      .then(async (res) => {
+        const data = await res.json();
+        if (!res.ok) {
+          showError(data.detail ?? '保存に失敗しました');
+          throw new Error('save failed');
+        }
+        return data;
+      })
       .then(() => {
         setIsCategoryMasterModalOpen(false);
         setEditingCategory(null);
@@ -749,8 +774,10 @@ export default function App() {
         refreshData();
       })
       .catch((err) => {
-        console.error('保存エラー:', err);
-        showError('保存に失敗しました');
+        if (err.message !== 'save failed') {
+          console.error('保存エラー:', err);
+          showError('保存に失敗しました');
+        }
       });
   };
 


### PR DESCRIPTION
## Summary
- validate that names can't be blank and show Japanese messages
- keep modal dialogs open on API error

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686755c8d45c83289751667850d9bbd9