### PR TITLE
Fix context menu location

### DIFF
--- a/my-medical-app/src/App.css
+++ b/my-medical-app/src/App.css
@@ -65,7 +65,7 @@
 }
 
 .context-menu {
-  position: absolute;
+  position: fixed;
   background: white;
   border: 1px solid #ccc;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- ensure the custom context menu uses `position: fixed` so it appears at the mouse cursor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686ccc93309483288d676390bce1e897