### PR TITLE
Sort facilities by short name at startup

### DIFF
--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -218,6 +218,11 @@ export default function App() {
             .map((f: Facility) => f.id)
             .filter((id: number) => !parsed.includes(id));
           order = [...parsed, ...missing];
+        } else {
+          order = list
+            .slice()
+            .sort((a, b) => a.short_name.localeCompare(b.short_name))
+            .map((f) => f.id);
         }
         setFacilityOrder(order);
         setCookie('facilityOrder', order.join(','));
@@ -470,6 +475,11 @@ export default function App() {
             .map((f: Facility) => f.id)
             .filter((id: number) => !parsed.includes(id));
           facOrder = [...parsed, ...missing];
+        } else {
+          facOrder = facList
+            .slice()
+            .sort((a, b) => a.short_name.localeCompare(b.short_name))
+            .map((f) => f.id);
         }
         setFacilityOrder(facOrder);
         setCookie('facilityOrder', facOrder.join(','));


### PR DESCRIPTION
## Summary
- order the medical facility list by short name when there is no saved ordering
- keep the user-defined order when a cookie is present

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686da928d0f88328ba81d053e7729d9c