### PR TITLE
Add toggle and multiline remarks for functions

### DIFF
--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -124,6 +124,7 @@ export default function App() {
   const [categoryListSearchMode, setCategoryListSearchMode] = useState<'AND' | 'OR'>('AND');
   const [showDeletedFunctions, setShowDeletedFunctions] = useState(false);
   const [showDeletedCategories, setShowDeletedCategories] = useState(false);
+  const [showFunctionRemarks, setShowFunctionRemarks] = useState(true);
 
   const [notification, setNotification] = useState<string | null>(null);
 
@@ -1213,6 +1214,22 @@ export default function App() {
           />
           <span>OR</span>
         </label>
+        <label className="flex items-center space-x-2">
+          <Switch
+            checked={showFunctionRemarks}
+            onChange={setShowFunctionRemarks}
+            className={`${
+              showFunctionRemarks ? 'bg-blue-500' : 'bg-gray-300'
+            } relative inline-flex h-6 w-11 items-center rounded-full`}
+          >
+            <span
+              className={`${
+                showFunctionRemarks ? 'translate-x-6' : 'translate-x-1'
+              } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+            />
+          </Switch>
+          <span>備考表示</span>
+        </label>
       </div>
 
         {/* テーブル */}
@@ -1337,7 +1354,21 @@ export default function App() {
                               {fEntry.selected_values.map((v, i) => (
                                 <div key={i}>{v}</div>
                               ))}
-                              {fEntry.remarks && <div>{fEntry.remarks}</div>}
+                              {showFunctionRemarks && fEntry.remarks && (
+                                (() => {
+                                  const lines = fEntry.remarks.split('\n');
+                                  const display = lines.slice(0, 2);
+                                  const truncated = lines.length > 2;
+                                  return (
+                                    <>
+                                      {display.map((l, i) => (
+                                        <div key={i}>{l}</div>
+                                      ))}
+                                      {truncated && <div>...</div>}
+                                    </>
+                                  );
+                                })()
+                              )}
                             </div>
                           ) : (
                             '-'


### PR DESCRIPTION
## Summary
- add a state flag to control whether function remarks are visible
- show a toggle above the facility list to show/hide remarks
- display function remarks up to two lines with ellipsis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686dcee0bbb88328bf539a77d59401ca