### PR TITLE
Remove sample memos and set tab title

### DIFF
--- a/my-medical-app/src/memo.tsx
+++ b/my-medical-app/src/memo.tsx
@@ -7,6 +7,11 @@ const params = new URLSearchParams(window.location.search);
 const facilityId = Number(params.get('facilityId')) || 0;
 const facilityName = params.get('facilityName') || '';
 
+// ブラウザタブのタイトルを医療機関名に更新
+if (facilityName) {
+  document.title = facilityName;
+}
+
 createRoot(document.getElementById('memo-root')!).render(
   <React.StrictMode>
     <MemoApp facilityId={facilityId} facilityName={facilityName} />

--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -10,20 +10,7 @@ export interface MemoItem {
   deleted?: boolean;
 }
 
-const initialMemos: MemoItem[] = [
-  {
-    id: 1,
-    title: '初回カウンセリング',
-    content: '# カウンセリング内容\n患者は...\n',
-    tags: ['初診'],
-  },
-  {
-    id: 2,
-    title: '定期検診メモ',
-    content: '## 検査結果\n- 血圧 正常\n- ...',
-    tags: ['検診'],
-  },
-];
+const initialMemos: MemoItem[] = [];
 
 interface Props {
   facilityId: number
@@ -32,7 +19,7 @@ interface Props {
 
 export default function MemoApp({ facilityId, facilityName }: Props) {
   const [memos] = useState<MemoItem[]>(initialMemos);
-  const [selectedId, setSelectedId] = useState<number | null>(initialMemos[0].id);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
   const [showDeleted, setShowDeleted] = useState(false);
   const [search, setSearch] = useState('');
   const [tagFilter] = useState<string[]>([]);


### PR DESCRIPTION
## Summary
- remove predefined demo memos from the memo screen
- update memo page to set document title from facility name

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f4d408ae083288305d8c76f50bb8a