### PR TITLE
Add memo creation and editing features

### DIFF
--- a/my-medical-app/src/components/ImeInput.tsx
+++ b/my-medical-app/src/components/ImeInput.tsx
@@ -3,7 +3,12 @@ import React, { forwardRef } from 'react';
 type Props = React.InputHTMLAttributes<HTMLInputElement>;
 
 const ImeInput = forwardRef<HTMLInputElement, Props>((props, ref) => (
-  <input lang="ja" inputMode={"kana" as any} {...props} ref={ref} />
+  <input
+    lang="ja"
+    inputMode={'kana' as unknown as React.InputHTMLAttributes<HTMLInputElement>['inputMode']}
+    {...props}
+    ref={ref}
+  />
 ));
 
 ImeInput.displayName = 'ImeInput';

--- a/my-medical-app/src/components/ImeTextarea.tsx
+++ b/my-medical-app/src/components/ImeTextarea.tsx
@@ -3,7 +3,12 @@ import React, { forwardRef } from 'react';
 type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const ImeTextarea = forwardRef<HTMLTextAreaElement, Props>((props, ref) => (
-  <textarea lang="ja" inputMode={"kana" as any} {...props} ref={ref} />
+  <textarea
+    lang="ja"
+    inputMode={'kana' as unknown as React.TextareaHTMLAttributes<HTMLTextAreaElement>['inputMode']}
+    {...props}
+    ref={ref}
+  />
 ));
 
 ImeTextarea.displayName = 'ImeTextarea';

--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import MemoList from './MemoList';
 import MemoViewer from './MemoViewer';
+import MemoEditor from './MemoEditor';
 
 export interface MemoItem {
   id: number;
@@ -18,8 +19,12 @@ interface Props {
 }
 
 export default function MemoApp({ facilityId, facilityName }: Props) {
-  const [memos] = useState<MemoItem[]>(initialMemos);
+  const [memos, setMemos] = useState<MemoItem[]>(initialMemos);
+  const [nextId, setNextId] = useState(() =>
+    memos.reduce((max, m) => Math.max(max, m.id), 0) + 1,
+  );
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [editing, setEditing] = useState<MemoItem | null>(null);
   const [showDeleted, setShowDeleted] = useState(false);
   const [search, setSearch] = useState('');
   const [tagFilter] = useState<string[]>([]);
@@ -32,6 +37,34 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
   });
 
   const selected = memos.find((m) => m.id === selectedId) || null;
+
+  const handleCreate = () => {
+    const memo: MemoItem = { id: nextId, title: '', content: '', tags: [] };
+    setNextId((v) => v + 1);
+    setEditing(memo);
+  };
+
+  const handleEdit = (memo: MemoItem) => {
+    setEditing({ ...memo });
+  };
+
+  const handleSave = (memo: MemoItem) => {
+    setMemos((prev) => {
+      const idx = prev.findIndex((m) => m.id === memo.id);
+      if (idx >= 0) {
+        const updated = [...prev];
+        updated[idx] = memo;
+        return updated;
+      }
+      return [...prev, memo];
+    });
+    setSelectedId(memo.id);
+    setEditing(null);
+  };
+
+  const handleToggleDelete = (id: number) => {
+    setMemos((prev) => prev.map((m) => (m.id === id ? { ...m, deleted: !m.deleted } : m)));
+  };
 
   return (
     <div className="flex flex-col h-screen">
@@ -48,9 +81,21 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
           onToggleDeleted={() => setShowDeleted((v) => !v)}
           search={search}
           onSearch={setSearch}
+          onCreate={handleCreate}
         />
-        <MemoViewer memo={selected} />
+        <MemoViewer
+          memo={selected}
+          onEdit={() => selected && handleEdit(selected)}
+          onToggleDelete={() => selected && handleToggleDelete(selected.id)}
+        />
       </div>
+      {editing && (
+        <MemoEditor
+          memo={editing}
+          onSave={handleSave}
+          onCancel={() => setEditing(null)}
+        />
+      )}
     </div>
   );
 }

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import Markdown from 'react-markdown';
+import ImeInput from '../components/ImeInput';
+import ImeTextarea from '../components/ImeTextarea';
+import type { MemoItem } from './MemoApp';
+
+interface Props {
+  memo: MemoItem;
+  onSave: (m: MemoItem) => void;
+  onCancel: () => void;
+}
+
+export default function MemoEditor({ memo, onSave, onCancel }: Props) {
+  const [title, setTitle] = useState(memo.title);
+  const [content, setContent] = useState(memo.content);
+  const [tags, setTags] = useState(memo.tags.join(','));
+
+  const handleSave = () => {
+    const tagArr = tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t);
+    onSave({ ...memo, title, content, tags: tagArr });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+      <div className="bg-white w-11/12 max-w-3xl p-4 rounded shadow flex flex-col h-[80%]">
+        <div className="flex-1 flex flex-col md:flex-row gap-4 overflow-hidden">
+          <div className="flex-1 flex flex-col">
+            <ImeInput
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="タイトル"
+              className="border p-1 mb-2"
+            />
+            <ImeTextarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              className="border p-1 flex-1"
+            />
+            <ImeInput
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder="タグ(カンマ区切り)"
+              className="border p-1 mt-2"
+            />
+          </div>
+          <div className="flex-1 overflow-auto p-2 border rounded bg-gray-50">
+            <div className="prose max-w-none">
+              <Markdown>{content}</Markdown>
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-end mt-2 space-x-2">
+          <button className="px-3 py-1 bg-gray-300 rounded" onClick={onCancel}>
+            キャンセル
+          </button>
+          <button className="px-3 py-1 bg-blue-500 text-white rounded" onClick={handleSave}>
+            保存
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/my-medical-app/src/memo/MemoList.tsx
+++ b/my-medical-app/src/memo/MemoList.tsx
@@ -9,6 +9,7 @@ interface Props {
   onToggleDeleted: () => void;
   search: string;
   onSearch: (v: string) => void;
+  onCreate: () => void;
 }
 
 export default function MemoList({
@@ -19,6 +20,7 @@ export default function MemoList({
   onToggleDeleted,
   search,
   onSearch,
+  onCreate,
 }: Props) {
   return (
     <div className="w-1/3 border-r overflow-y-auto p-2 space-y-2">
@@ -40,7 +42,10 @@ export default function MemoList({
           削除済み
         </label>
       </div>
-      <button className="bg-blue-500 text-white px-2 py-1 rounded w-full mb-2">
+      <button
+        className="bg-blue-500 text-white px-2 py-1 rounded w-full mb-2"
+        onClick={onCreate}
+      >
         ＋新規作成
       </button>
       <ul className="space-y-1">

--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -3,14 +3,27 @@ import Markdown from 'react-markdown';
 
 interface Props {
   memo: MemoItem | null;
+  onEdit: () => void;
+  onToggleDelete: () => void;
 }
 
-export default function MemoViewer({ memo }: Props) {
+export default function MemoViewer({ memo, onEdit, onToggleDelete }: Props) {
   if (!memo) return <div className="flex-1 p-4">メモを選択してください</div>;
   return (
     <div className="flex-1 p-4 overflow-y-auto">
       <div className="flex justify-end mb-2">
-        <button className="bg-green-500 text-white px-2 py-1 rounded">編集</button>
+        <button
+          className="bg-green-500 text-white px-2 py-1 rounded mr-2"
+          onClick={onEdit}
+        >
+          編集
+        </button>
+        <button
+          className="bg-red-500 text-white px-2 py-1 rounded"
+          onClick={onToggleDelete}
+        >
+          {memo.deleted ? '復元' : '削除'}
+        </button>
       </div>
       <div className="prose max-w-none">
         <Markdown>{memo.content}</Markdown>


### PR DESCRIPTION
## Summary
- implement simple editor modal for facility memos
- allow creation, editing and deletion of memos
- expose callbacks from list and viewer to manage memos
- fix lint errors in IME components

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f4e241878832898ecc71000183470