### PR TITLE
Add memo tag management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ uvicorn backend.app.main:app --reload --port 8001
 ## サブディレクトリ README
 - [backend/README.md](backend/README.md)
 - [my-medical-app/README.md](my-medical-app/README.md)
+
+### メモ機能のマークダウン見出し
+メモ編集では `#` 記号の後に半角スペースを入れると見出しとして表示されます。
+例: `# タイトル`

--- a/my-medical-app/memo_tags.html
+++ b/my-medical-app/memo_tags.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>タグマスタ保守</title>
+  </head>
+  <body>
+    <div id="tag-root"></div>
+    <script type="module" src="/src/tagMaster.tsx"></script>
+  </body>
+</html>

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -4,11 +4,11 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import ImeInput from '../components/ImeInput';
 import ImeTextarea from '../components/ImeTextarea';
-import type { MemoItem } from './MemoApp';
+import type { MemoItem, MemoTag } from './MemoApp';
 
 interface Props {
   memo: MemoItem;
-  tagOptions: string[];
+  tagOptions: MemoTag[];
   onSave: (m: MemoItem) => void;
   onCancel: () => void;
 }
@@ -16,10 +16,10 @@ interface Props {
 export default function MemoEditor({ memo, tagOptions, onSave, onCancel }: Props) {
   const [title, setTitle] = useState(memo.title);
   const [content, setContent] = useState(memo.content);
-  const [tags, setTags] = useState<string[]>(memo.tags);
+  const [tags, setTags] = useState<number[]>(memo.tag_ids);
 
   const handleSave = () => {
-    onSave({ ...memo, title, content, tags });
+    onSave({ ...memo, title, content, tag_ids: tags });
   };
 
   return (
@@ -40,20 +40,20 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel }: Props
             />
             <div className="border p-1 mt-2 space-y-1">
               {tagOptions.map((tag) => (
-                <label key={tag} className="block text-sm">
+                <label key={tag.id} className="block text-sm">
                   <input
                     type="checkbox"
                     className="mr-1"
-                    checked={tags.includes(tag)}
+                    checked={tags.includes(tag.id)}
                     onChange={(e) => {
                       if (e.target.checked) {
-                        setTags((prev) => [...prev, tag]);
+                        setTags((prev) => [...prev, tag.id]);
                       } else {
-                        setTags((prev) => prev.filter((t) => t !== tag));
+                        setTags((prev) => prev.filter((t) => t !== tag.id));
                       }
                     }}
                   />
-                  {tag}
+                  {tag.name}
                 </label>
               ))}
             </div>

--- a/my-medical-app/src/memo/MemoTagManager.tsx
+++ b/my-medical-app/src/memo/MemoTagManager.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import ImeInput from '../components/ImeInput';
+import type { MemoTag } from './MemoApp';
+
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8001';
+
+export default function MemoTagManager() {
+  const [tags, setTags] = useState<MemoTag[]>([]);
+  const [name, setName] = useState('');
+  const [remark, setRemark] = useState('');
+  const [editing, setEditing] = useState<MemoTag | null>(null);
+
+  const fetchTags = () => {
+    fetch(`${apiBase}/memo-tags?include_deleted=true`)
+      .then((res) => res.json())
+      .then((data) => setTags(data));
+  };
+
+  useEffect(() => {
+    fetchTags();
+  }, []);
+
+  const handleSubmit = () => {
+    const method = editing ? 'PUT' : 'POST';
+    const url = editing ? `${apiBase}/memo-tags/${editing.id}` : `${apiBase}/memo-tags`;
+    fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, remark }),
+    }).then(() => {
+      setName('');
+      setRemark('');
+      setEditing(null);
+      fetchTags();
+    });
+  };
+
+  const handleDelete = (tag: MemoTag) => {
+    fetch(`${apiBase}/memo-tags/${tag.id}`, { method: 'DELETE' }).then(fetchTags);
+  };
+
+  const handleRestore = (tag: MemoTag) => {
+    fetch(`${apiBase}/memo-tags/${tag.id}/restore`, { method: 'PUT' }).then(fetchTags);
+  };
+
+  const startEdit = (tag: MemoTag) => {
+    setEditing(tag);
+    setName(tag.name);
+    setRemark(tag.remark || '');
+  };
+
+  const cancelEdit = () => {
+    setEditing(null);
+    setName('');
+    setRemark('');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">タグマスタ保守</h1>
+      <div className="space-y-2">
+        <ImeInput
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="タグ名"
+          className="border p-1"
+        />
+        <ImeInput
+          value={remark}
+          onChange={(e) => setRemark(e.target.value)}
+          placeholder="備考"
+          className="border p-1"
+        />
+        <button className="bg-blue-500 text-white px-2 py-1 rounded" onClick={handleSubmit}>
+          {editing ? '更新' : '追加'}
+        </button>
+        {editing && (
+          <button className="ml-2 px-2 py-1 bg-gray-300 rounded" onClick={cancelEdit}>
+            キャンセル
+          </button>
+        )}
+      </div>
+      <table className="min-w-full border">
+        <thead>
+          <tr>
+            <th className="border p-1">ID</th>
+            <th className="border p-1">名前</th>
+            <th className="border p-1">備考</th>
+            <th className="border p-1">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tags.map((tag) => (
+            <tr key={tag.id} className="border">
+              <td className="border p-1 text-center">{tag.id}</td>
+              <td className="border p-1">{tag.name}</td>
+              <td className="border p-1">{tag.remark}</td>
+              <td className="border p-1 space-x-1">
+                <button className="px-1 bg-green-500 text-white" onClick={() => startEdit(tag)}>
+                  編集
+                </button>
+                {tag.is_deleted ? (
+                  <button className="px-1 bg-yellow-500 text-white" onClick={() => handleRestore(tag)}>
+                    復元
+                  </button>
+                ) : (
+                  <button className="px-1 bg-red-500 text-white" onClick={() => handleDelete(tag)}>
+                    削除
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -1,16 +1,21 @@
-import type { MemoItem } from './MemoApp';
+import type { MemoItem, MemoTag } from './MemoApp';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 
 interface Props {
   memo: MemoItem | null;
+  tagOptions: MemoTag[];
   onEdit: () => void;
   onToggleDelete: () => void;
 }
 
-export default function MemoViewer({ memo, onEdit, onToggleDelete }: Props) {
+export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete }: Props) {
   if (!memo) return <div className="flex-1 p-4">メモを選択してください</div>;
+  const tags = memo.tag_ids
+    .map((id) => tagOptions.find((t) => t.id === id)?.name)
+    .filter(Boolean)
+    .join(', ');
   return (
     <div className="flex-1 p-4 overflow-y-auto">
       <div className="flex justify-end mb-2">
@@ -30,6 +35,7 @@ export default function MemoViewer({ memo, onEdit, onToggleDelete }: Props) {
       <div className="prose max-w-none">
         <Markdown remarkPlugins={[remarkGfm, remarkBreaks]}>{memo.content}</Markdown>
       </div>
+      {tags && <div className="mt-2 text-sm text-gray-600">タグ: {tags}</div>}
     </div>
   );
 }

--- a/my-medical-app/src/tagMaster.tsx
+++ b/my-medical-app/src/tagMaster.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import MemoTagManager from './memo/MemoTagManager';
+import './index.css';
+
+createRoot(document.getElementById('tag-root')!).render(
+  <React.StrictMode>
+    <MemoTagManager />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Summary
- implement tag master maintenance page with CRUD
- fetch memo tags from API in memo app
- adapt memo editor/viewer to use tag ids
- add memo tag manager entry HTML and bootstrap file
- document heading syntax requirement

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f55eb196c832890b840968b276526