### PR TITLE
Enable modal-based tag management

### DIFF
--- a/my-medical-app/src/components/VerticalSplit.tsx
+++ b/my-medical-app/src/components/VerticalSplit.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface Props {
+  left: React.ReactNode;
+  right: React.ReactNode;
+  storageKey: string;
+  initialLeftWidth: number;
+}
+
+const getCookie = (name: string): string | null => {
+  const m = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return m ? decodeURIComponent(m[1]) : null;
+};
+
+const setCookie = (name: string, value: string) => {
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=31536000`;
+};
+
+export default function VerticalSplit({ left, right, storageKey, initialLeftWidth }: Props) {
+  const [leftWidth, setLeftWidth] = useState(() => {
+    const c = getCookie(storageKey);
+    return c ? Number(c) : initialLeftWidth;
+  });
+
+  useEffect(() => {
+    setCookie(storageKey, String(leftWidth));
+  }, [leftWidth, storageKey]);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = leftWidth;
+      const onMove = (ev: MouseEvent) => {
+        const delta = ev.clientX - startX;
+        setLeftWidth(Math.max(150, startWidth + delta));
+      };
+      const onUp = () => {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+      };
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [leftWidth],
+  );
+
+  return (
+    <div className="flex flex-1 overflow-hidden h-full">
+      <div style={{ width: leftWidth }} className="border-r">
+        {left}
+      </div>
+      <div className="w-2 cursor-col-resize bg-gray-200" onMouseDown={onMouseDown} />
+      <div className="flex-1">
+        {right}
+      </div>
+    </div>
+  );
+}

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -11,9 +11,10 @@ interface Props {
   tagOptions: MemoTag[];
   onSave: (m: MemoItem) => void;
   onCancel: () => void;
+  onOpenTagMaster: () => void;
 }
 
-export default function MemoEditor({ memo, tagOptions, onSave, onCancel }: Props) {
+export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenTagMaster }: Props) {
   const [title, setTitle] = useState(memo.title);
   const [content, setContent] = useState(memo.content);
   const [tags, setTags] = useState<number[]>(memo.tag_ids);
@@ -21,6 +22,7 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel }: Props
   const handleSave = () => {
     onSave({ ...memo, title, content, tag_ids: tags });
   };
+
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
@@ -38,7 +40,14 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel }: Props
               onChange={(e) => setContent(e.target.value)}
               className="border p-1 flex-1"
             />
-            <div className="border p-1 mt-2 space-y-1">
+            <div className="border p-1 mt-2 space-y-1 relative pr-20">
+              <button
+                type="button"
+                className="absolute top-1 right-1 bg-blue-500 text-white text-xs px-2 py-1 rounded"
+                onClick={onOpenTagMaster}
+              >
+                タグ管理
+              </button>
               {tagOptions.map((tag) => (
                 <label key={tag.id} className="block text-sm">
                   <input

--- a/my-medical-app/src/memo/MemoList.tsx
+++ b/my-medical-app/src/memo/MemoList.tsx
@@ -10,6 +10,7 @@ interface Props {
   search: string;
   onSearch: (v: string) => void;
   onCreate: () => void;
+  className?: string;
 }
 
 export default function MemoList({
@@ -21,9 +22,10 @@ export default function MemoList({
   search,
   onSearch,
   onCreate,
+  className = '',
 }: Props) {
   return (
-    <div className="w-1/3 border-r overflow-y-auto p-2 space-y-2">
+    <div className={`overflow-y-auto p-2 space-y-2 ${className}`}>
       <div className="flex items-center justify-between mb-2">
         <ImeInput
           type="text"

--- a/my-medical-app/src/memo/MemoTagManagerModal.tsx
+++ b/my-medical-app/src/memo/MemoTagManagerModal.tsx
@@ -1,0 +1,28 @@
+import { Dialog, Transition } from '@headlessui/react';
+import { Fragment } from 'react';
+import MemoTagManager from './MemoTagManager';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function MemoTagManagerModal({ isOpen, onClose }: Props) {
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={onClose}>
+        <div className="fixed inset-0 bg-black bg-opacity-25" />
+        <div className="fixed inset-0 overflow-y-auto flex items-center justify-center p-4">
+          <Dialog.Panel className="w-full max-w-lg bg-white rounded p-6 shadow">
+            <MemoTagManager />
+            <div className="flex justify-end mt-4">
+              <button className="px-4 py-2 bg-gray-500 text-white rounded" onClick={onClose}>
+                閉じる
+              </button>
+            </div>
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}


### PR DESCRIPTION
## Summary
- add `MemoTagManagerModal` for managing tags in a dialog
- open the modal from memo editor instead of a new tab
- refresh tag list after closing the modal

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f5b26f01c832899d1f4da861e03d2