### PR TITLE
Implement multi-select for memo tags

### DIFF
--- a/my-medical-app/src/components/MultiSelect.tsx
+++ b/my-medical-app/src/components/MultiSelect.tsx
@@ -1,0 +1,96 @@
+import { Listbox, Transition } from '@headlessui/react';
+import { Fragment, useState } from 'react';
+
+export interface Option {
+  value: number;
+  label: string;
+}
+
+interface Props {
+  options: Option[];
+  selected: number[];
+  onChange: (values: number[]) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export default function MultiSelect({
+  options,
+  selected,
+  onChange,
+  placeholder = '選択...',
+  className = '',
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  const toggleValue = (value: number) => {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  };
+
+  const selectedLabels = selected
+    .map((v) => options.find((o) => o.value === v)?.label)
+    .filter(Boolean);
+
+  return (
+    <Listbox value={selected} onChange={onChange} multiple>
+      {() => (
+        <div className={`relative ${className}`}>
+          <Listbox.Button
+            onClick={() => setOpen((o) => !o)}
+            className="w-full border rounded px-2 py-1 text-left"
+          >
+            {selectedLabels.length ? (
+              <div className="flex flex-wrap gap-1">
+                {selectedLabels.map((label) => (
+                  <span
+                    key={label}
+                    className="bg-blue-100 text-blue-800 px-1 rounded text-sm"
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <span className="text-gray-400">{placeholder}</span>
+            )}
+          </Listbox.Button>
+          <Transition
+            show={open}
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Listbox.Options className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded bg-white border shadow">
+              {options.map((opt) => (
+                <Listbox.Option
+                  key={opt.value}
+                  value={opt.value}
+                  as={Fragment}
+                >
+                  {({ active }) => (
+                    <li
+                      className={`cursor-pointer select-none py-1 pl-2 pr-4 flex items-center gap-2 ${active ? 'bg-blue-100' : ''}`}
+                      onClick={() => toggleValue(opt.value)}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected.includes(opt.value)}
+                        readOnly
+                      />
+                      <span>{opt.label}</span>
+                    </li>
+                  )}
+                </Listbox.Option>
+              ))}
+            </Listbox.Options>
+          </Transition>
+        </div>
+      )}
+    </Listbox>
+  );
+}

--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -39,7 +39,7 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
   const [editing, setEditing] = useState<MemoItem | null>(null);
   const [showDeleted, setShowDeleted] = useState(false);
   const [search, setSearch] = useState('');
-  const [tagFilter] = useState<number[]>([]);
+  const [tagFilter, setTagFilter] = useState<number[]>([]);
 
   const fetchTags = useCallback(() => {
     fetch(`${apiBase}/memo-tags`)
@@ -106,6 +106,9 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
             onToggleDeleted={() => setShowDeleted((v) => !v)}
             search={search}
             onSearch={setSearch}
+            tagOptions={tagMaster}
+            tagFilter={tagFilter}
+            onTagFilterChange={setTagFilter}
             onCreate={handleCreate}
           />
         }

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -4,6 +4,7 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import ImeInput from '../components/ImeInput';
 import ImeTextarea from '../components/ImeTextarea';
+import MultiSelect, { Option } from '../components/MultiSelect';
 import type { MemoItem, MemoTag } from './MemoApp';
 
 interface Props {
@@ -18,6 +19,8 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
   const [title, setTitle] = useState(memo.title);
   const [content, setContent] = useState(memo.content);
   const [tags, setTags] = useState<number[]>(memo.tag_ids);
+
+  const options: Option[] = tagOptions.map((t) => ({ value: t.id, label: t.name }));
 
   const handleSave = () => {
     onSave({ ...memo, title, content, tag_ids: tags });
@@ -48,23 +51,12 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
               >
                 タグ管理
               </button>
-              {tagOptions.map((tag) => (
-                <label key={tag.id} className="block text-sm">
-                  <input
-                    type="checkbox"
-                    className="mr-1"
-                    checked={tags.includes(tag.id)}
-                    onChange={(e) => {
-                      if (e.target.checked) {
-                        setTags((prev) => [...prev, tag.id]);
-                      } else {
-                        setTags((prev) => prev.filter((t) => t !== tag.id));
-                      }
-                    }}
-                  />
-                  {tag.name}
-                </label>
-              ))}
+              <MultiSelect
+                options={options}
+                selected={tags}
+                onChange={setTags}
+                placeholder="タグを選択"
+              />
             </div>
           </div>
           <div className="flex-1 overflow-auto p-2 border rounded bg-gray-50">

--- a/my-medical-app/src/memo/MemoList.tsx
+++ b/my-medical-app/src/memo/MemoList.tsx
@@ -1,5 +1,7 @@
 import type { MemoItem } from './MemoApp';
 import ImeInput from '../components/ImeInput';
+import MultiSelect, { Option } from '../components/MultiSelect';
+import type { MemoTag } from './MemoApp';
 
 interface Props {
   memos: MemoItem[];
@@ -9,6 +11,9 @@ interface Props {
   onToggleDeleted: () => void;
   search: string;
   onSearch: (v: string) => void;
+  tagOptions: MemoTag[];
+  tagFilter: number[];
+  onTagFilterChange: (v: number[]) => void;
   onCreate: () => void;
   className?: string;
 }
@@ -21,9 +26,13 @@ export default function MemoList({
   onToggleDeleted,
   search,
   onSearch,
+  tagOptions,
+  tagFilter,
+  onTagFilterChange,
   onCreate,
   className = '',
 }: Props) {
+  const options: Option[] = tagOptions.map((t) => ({ value: t.id, label: t.name }));
   return (
     <div className={`overflow-y-auto p-2 space-y-2 ${className}`}>
       <div className="flex items-center justify-between mb-2">
@@ -44,6 +53,13 @@ export default function MemoList({
           削除済み
         </label>
       </div>
+      <MultiSelect
+        options={options}
+        selected={tagFilter}
+        onChange={onTagFilterChange}
+        placeholder="タグで絞り込み"
+        className="mb-2"
+      />
       <button
         className="bg-blue-500 text-white px-2 py-1 rounded w-full mb-2"
         onClick={onCreate}


### PR DESCRIPTION
## Summary
- add generic `MultiSelect` component using Headless UI
- switch memo editor tag selection to use multi-select UI
- enable tag filtering in memo list with the same component
- store selected tags in `MemoApp`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_686f65f907608328b549218f31a51ba5