### PR TITLE
Allow memo creation without tags

### DIFF
--- a/backend/app/routers/memo.py
+++ b/backend/app/routers/memo.py
@@ -29,7 +29,7 @@ def create_memo(facility_id: int, memo: schemas.FacilityMemoCreate, db: Session 
     db.add(db_memo)
     db.commit()
     db.refresh(db_memo)
-    for tag_id in memo.tag_ids:
+    for tag_id in memo.tag_ids or []:
         db.add(models.FacilityMemoTagLink(memo_id=db_memo.id, tag_id=tag_id))
     db.commit()
     db.refresh(db_memo)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, validator
 from typing import Optional, List
+from datetime import datetime
 
 
 class ContactInfo(BaseModel):
@@ -183,7 +184,7 @@ class FacilityMemoBase(BaseModel):
     title: str
     content: Optional[str]
     is_deleted: bool
-    updated_at: Optional[str]
+    updated_at: Optional[datetime]
     tags: List[MemoTagBase] = []
 
     class Config:
@@ -191,10 +192,9 @@ class FacilityMemoBase(BaseModel):
 
 
 class FacilityMemoCreate(BaseModel):
-    facility_id: int
     title: str
     content: Optional[str] = None
-    tag_ids: List[int] = []
+    tag_ids: Optional[List[int]] = None
 
     @validator("title")
     def validate_title(cls, v: str) -> str:


### PR DESCRIPTION
## Summary
- make `tag_ids` optional in memo creation schema
- handle missing tag list when creating memos
- fix `updated_at` type so memo listing works

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*


------
https://chatgpt.com/codex/tasks/task_e_686f7736f0f883289474b4388c67790e