### PR TITLE
Implement memo history and lock features

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -209,3 +209,23 @@ class FacilityMemoUpdate(BaseModel):
     tag_ids: Optional[List[int]] = None
 
 
+class FacilityMemoVersionBase(BaseModel):
+    id: int
+    memo_id: int
+    version_no: int
+    content: Optional[str]
+    created_at: Optional[datetime]
+
+    class Config:
+        from_attributes = True
+
+
+class FacilityMemoLockBase(BaseModel):
+    memo_id: int
+    locked_by: Optional[str]
+    locked_at: Optional[datetime]
+
+    class Config:
+        from_attributes = True
+
+

--- a/my-medical-app/src/memo/MemoHistoryModal.tsx
+++ b/my-medical-app/src/memo/MemoHistoryModal.tsx
@@ -1,0 +1,63 @@
+import { Dialog, Transition } from '@headlessui/react';
+import { Fragment, useEffect, useState } from 'react';
+
+interface Version {
+  id: number;
+  memo_id: number;
+  version_no: number;
+  content: string | null;
+  created_at: string;
+}
+
+interface Props {
+  memoId: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onRestore: (versionNo: number) => void;
+}
+
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8001';
+
+export default function MemoHistoryModal({ memoId, isOpen, onClose, onRestore }: Props) {
+  const [versions, setVersions] = useState<Version[]>([]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    fetch(`${apiBase}/memos/${memoId}/versions`)
+      .then((res) => res.json())
+      .then((data: Version[]) => setVersions(data));
+  }, [memoId, isOpen]);
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-[60]" onClose={onClose}>
+        <div className="fixed inset-0 bg-black bg-opacity-25" />
+        <div className="fixed inset-0 overflow-y-auto flex items-center justify-center p-4">
+          <Dialog.Panel className="w-full max-w-lg bg-white rounded p-4 shadow">
+            <Dialog.Title className="text-lg font-bold mb-2">履歴</Dialog.Title>
+            <ul className="space-y-2 max-h-80 overflow-y-auto">
+              {versions.map((v) => (
+                <li key={v.id} className="border p-2 flex justify-between items-center">
+                  <span>
+                    {`#${v.version_no}`} {new Date(v.created_at).toLocaleString()}
+                  </span>
+                  <button
+                    className="px-2 py-1 bg-blue-500 text-white text-sm rounded"
+                    onClick={() => onRestore(v.version_no)}
+                  >
+                    復元
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-end mt-4">
+              <button className="px-4 py-2 bg-gray-500 text-white rounded" onClick={onClose}>
+                閉じる
+              </button>
+            </div>
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -8,9 +8,10 @@ interface Props {
   tagOptions: MemoTag[];
   onEdit: () => void;
   onToggleDelete: () => void;
+  onShowHistory: () => void;
 }
 
-export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete }: Props) {
+export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, onShowHistory }: Props) {
   if (!memo) return <div className="flex-1 p-4">メモを選択してください</div>;
   const tags = memo.tag_ids
     .map((id) => tagOptions.find((t) => t.id === id)?.name)
@@ -18,12 +19,18 @@ export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete }:
     .join(', ');
   return (
     <div className="flex-1 p-4 overflow-y-auto">
-      <div className="flex justify-end mb-2">
+      <div className="flex justify-end mb-2 space-x-2">
         <button
           className="bg-green-500 text-white px-2 py-1 rounded mr-2"
           onClick={onEdit}
         >
           編集
+        </button>
+        <button
+          className="bg-blue-500 text-white px-2 py-1 rounded"
+          onClick={onShowHistory}
+        >
+          履歴
         </button>
         <button
           className="bg-red-500 text-white px-2 py-1 rounded"


### PR DESCRIPTION
## Summary
- add history & lock schemas for memos
- implement history endpoints and locking REST APIs
- show memo history modal in front-end
- implement editing lock logic when editing memos

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f7c3222608328bb0950b69b6e6a6e