### PR TITLE
Enable viewing memo versions

### DIFF
--- a/my-medical-app/src/components/MultiSelect.tsx
+++ b/my-medical-app/src/components/MultiSelect.tsx
@@ -12,6 +12,7 @@ interface Props {
   onChange: (values: number[]) => void;
   placeholder?: string;
   className?: string;
+  disabled?: boolean;
 }
 
 export default function MultiSelect({
@@ -20,10 +21,12 @@ export default function MultiSelect({
   onChange,
   placeholder = '選択...',
   className = '',
+  disabled = false,
 }: Props) {
   const [open, setOpen] = useState(false);
 
   const toggleValue = (value: number) => {
+    if (disabled) return;
     if (selected.includes(value)) {
       onChange(selected.filter((v) => v !== value));
     } else {
@@ -36,12 +39,12 @@ export default function MultiSelect({
     .filter(Boolean);
 
   return (
-    <Listbox value={selected} onChange={onChange} multiple>
+    <Listbox value={selected} onChange={onChange} multiple disabled={disabled}>
       {() => (
         <div className={`relative ${className}`}>
           <Listbox.Button
-            onClick={() => setOpen((o) => !o)}
-            className="w-full border rounded px-2 py-1 text-left"
+            onClick={() => !disabled && setOpen((o) => !o)}
+            className={`w-full border rounded px-2 py-1 text-left ${disabled ? 'bg-gray-100 cursor-not-allowed' : ''}`}
           >
             {selectedLabels.length ? (
               <div className="flex flex-wrap gap-1">

--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -56,6 +56,7 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
   const [isTagMasterOpen, setIsTagMasterOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [editing, setEditing] = useState<MemoItem | null>(null);
+  const [editingReadOnly, setEditingReadOnly] = useState(false);
   const [showDeleted, setShowDeleted] = useState(false);
   const [search, setSearch] = useState('');
   const [tagFilter, setTagFilter] = useState<number[]>([]);
@@ -123,6 +124,7 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
   const handleCreate = () => {
     const memo: MemoItem = { id: 0, title: '', content: '', tag_ids: [] };
     setEditing(memo);
+    setEditingReadOnly(false);
   };
 
   const handleEdit = (memo: MemoItem) => {
@@ -130,6 +132,7 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
       .then((res) => {
         if (res.ok) {
           setEditing({ ...memo });
+          setEditingReadOnly(false);
         } else {
           alert('他のユーザーが編集中です');
         }
@@ -182,6 +185,13 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
       });
   };
 
+  const handleViewVersion = (v: { version_no: number; content: string | null }) => {
+    if (!selected) return;
+    setEditing({ ...selected, content: v.content || '' });
+    setEditingReadOnly(true);
+    setIsHistoryOpen(false);
+  };
+
   return (
     <div className="flex flex-col h-screen">
       <header className="bg-blue-600 text-white p-2">
@@ -222,10 +232,12 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
           tagOptions={tagMaster}
           onSave={handleSave}
           onCancel={() => {
-            if (editing.id !== 0) unlockMemo(editing.id);
+            if (!editingReadOnly && editing.id !== 0) unlockMemo(editing.id);
             setEditing(null);
+            setEditingReadOnly(false);
           }}
           onOpenTagMaster={() => setIsTagMasterOpen(true)}
+          readOnly={editingReadOnly}
         />
       )}
       <MemoTagManagerModal
@@ -241,6 +253,7 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
           isOpen={isHistoryOpen}
           onClose={() => setIsHistoryOpen(false)}
           onRestore={handleRestoreVersion}
+          onView={handleViewVersion}
         />
       )}
     </div>

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -14,9 +14,10 @@ interface Props {
   onSave: (m: MemoItem) => void;
   onCancel: () => void;
   onOpenTagMaster: () => void;
+  readOnly?: boolean;
 }
 
-export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenTagMaster }: Props) {
+export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenTagMaster, readOnly = false }: Props) {
   const [title, setTitle] = useState(memo.title);
   const [content, setContent] = useState(memo.content);
   const [tags, setTags] = useState<number[]>(memo.tag_ids);
@@ -24,6 +25,7 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
   const options: Option[] = tagOptions.map((t) => ({ value: t.id, label: t.name }));
 
   const handleSave = () => {
+    if (readOnly) return;
     onSave({ ...memo, title, content, tag_ids: tags });
   };
 
@@ -38,25 +40,30 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
               onChange={(e) => setTitle(e.target.value)}
               placeholder="タイトル"
               className="border p-1 mb-2"
+              disabled={readOnly}
             />
             <ImeTextarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
               className="border p-1 flex-1"
+              disabled={readOnly}
             />
             <div className="border p-1 mt-2 space-y-1 relative pr-20">
-              <button
-                type="button"
-                className="absolute top-1 right-1 bg-blue-500 text-white text-xs px-2 py-1 rounded"
-                onClick={onOpenTagMaster}
-              >
-                タグ管理
-              </button>
+              {!readOnly && (
+                <button
+                  type="button"
+                  className="absolute top-1 right-1 bg-blue-500 text-white text-xs px-2 py-1 rounded"
+                  onClick={onOpenTagMaster}
+                >
+                  タグ管理
+                </button>
+              )}
               <MultiSelect
                 options={options}
                 selected={tags}
                 onChange={setTags}
                 placeholder="タグを選択"
+                disabled={readOnly}
               />
             </div>
           </div>
@@ -68,11 +75,13 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
         </div>
         <div className="flex justify-end mt-2 space-x-2">
           <button className="px-3 py-1 bg-gray-300 rounded" onClick={onCancel}>
-            キャンセル
+            {readOnly ? '閉じる' : 'キャンセル'}
           </button>
-          <button className="px-3 py-1 bg-blue-500 text-white rounded" onClick={handleSave}>
-            保存
-          </button>
+          {!readOnly && (
+            <button className="px-3 py-1 bg-blue-500 text-white rounded" onClick={handleSave}>
+              保存
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/my-medical-app/src/memo/MemoHistoryModal.tsx
+++ b/my-medical-app/src/memo/MemoHistoryModal.tsx
@@ -14,11 +14,12 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onRestore: (versionNo: number) => void;
+  onView: (version: Version) => void;
 }
 
 const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8001';
 
-export default function MemoHistoryModal({ memoId, isOpen, onClose, onRestore }: Props) {
+export default function MemoHistoryModal({ memoId, isOpen, onClose, onRestore, onView }: Props) {
   const [versions, setVersions] = useState<Version[]>([]);
 
   useEffect(() => {
@@ -37,16 +38,24 @@ export default function MemoHistoryModal({ memoId, isOpen, onClose, onRestore }:
             <Dialog.Title className="text-lg font-bold mb-2">履歴</Dialog.Title>
             <ul className="space-y-2 max-h-80 overflow-y-auto">
               {versions.map((v) => (
-                <li key={v.id} className="border p-2 flex justify-between items-center">
+                <li key={v.id} className="border p-2 flex justify-between items-center gap-2">
                   <span>
                     {`#${v.version_no}`} {new Date(v.created_at).toLocaleString()}
                   </span>
-                  <button
-                    className="px-2 py-1 bg-blue-500 text-white text-sm rounded"
-                    onClick={() => onRestore(v.version_no)}
-                  >
-                    復元
-                  </button>
+                  <div className="space-x-2">
+                    <button
+                      className="px-2 py-1 bg-green-500 text-white text-sm rounded"
+                      onClick={() => onView(v)}
+                    >
+                      表示
+                    </button>
+                    <button
+                      className="px-2 py-1 bg-blue-500 text-white text-sm rounded"
+                      onClick={() => onRestore(v.version_no)}
+                    >
+                      復元
+                    </button>
+                  </div>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- extend `MultiSelect` to support disabled state
- add `readOnly` prop to `MemoEditor`
- allow opening a memo version from history

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f8058b9848328841e686fc78d5384