### PR TITLE
Fix history modal closing when viewing version

### DIFF
--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -189,7 +189,6 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
     if (!selected) return;
     setEditing({ ...selected, content: v.content || '' });
     setEditingReadOnly(true);
-    setIsHistoryOpen(false);
   };
 
   return (

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -31,7 +31,7 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
 
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-[70]">
       <div className="bg-white w-11/12 max-w-3xl p-4 rounded shadow flex flex-col h-[80%]">
         <div className="flex-1 flex flex-col md:flex-row gap-4">
           <div className="flex-1 flex flex-col">


### PR DESCRIPTION
## Summary
- keep history modal open when viewing a version
- ensure the editor stays above the history screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f81dd24f88328a926fbeb2e384ea0