### PR TITLE
Add IP tracking to memo locks and history

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,18 @@
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, ARRAY, CheckConstraint, Boolean, JSON, TIMESTAMP
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    ForeignKey,
+    ARRAY,
+    CheckConstraint,
+    Boolean,
+    JSON,
+    TIMESTAMP,
+)
 from sqlalchemy.orm import relationship
 from .database import Base
+
 
 # 機能カテゴリテーブル
 class FunctionCategory(Base):
@@ -12,6 +24,7 @@ class FunctionCategory(Base):
     is_deleted = Column(Boolean, default=False)
 
     functions = relationship("Function", back_populates="category")
+
 
 # 医療機関テーブル
 class MedicalFacility(Base):
@@ -30,7 +43,10 @@ class MedicalFacility(Base):
     is_deleted = Column(Boolean, default=False)
 
     # 関連する機能情報をリレーションで持たせる
-    functions = relationship("FacilityFunctionEntry", back_populates="facility", cascade="all, delete-orphan")
+    functions = relationship(
+        "FacilityFunctionEntry", back_populates="facility", cascade="all, delete-orphan"
+    )
+
 
 # 機能マスタテーブル
 class Function(Base):
@@ -40,14 +56,19 @@ class Function(Base):
     name = Column(Text, nullable=False)
     description = Column(Text)
     memo = Column(Text)
-    selection_type = Column(Text, CheckConstraint("selection_type IN ('single', 'multiple')"))
+    selection_type = Column(
+        Text, CheckConstraint("selection_type IN ('single', 'multiple')")
+    )
     choices = Column(ARRAY(Text))
     category_id = Column(Integer, ForeignKey("function_categories.id"))
     is_deleted = Column(Boolean, default=False)
 
     category = relationship("FunctionCategory", back_populates="functions")
     # 機能エントリ（中間テーブル）側からの逆参照
-    entries = relationship("FacilityFunctionEntry", back_populates="function", cascade="all, delete-orphan")
+    entries = relationship(
+        "FacilityFunctionEntry", back_populates="function", cascade="all, delete-orphan"
+    )
+
 
 # 中間テーブル：施設と機能の紐づけ
 class FacilityFunctionEntry(Base):
@@ -63,6 +84,7 @@ class FacilityFunctionEntry(Base):
     facility = relationship("MedicalFacility", back_populates="functions")
     # リレーション：機能
     function = relationship("Function", back_populates="entries")
+
 
 # メモタグマスタ
 class MemoTag(Base):
@@ -118,6 +140,7 @@ class FacilityMemoVersion(Base):
     version_no = Column(Integer, nullable=False)
     content = Column(Text)
     created_at = Column(TIMESTAMP, server_default="now()")
+    ip_address = Column(Text)
 
     memo = relationship("FacilityMemo", back_populates="versions")
 
@@ -125,15 +148,20 @@ class FacilityMemoVersion(Base):
 class FacilityMemoTagLink(Base):
     __tablename__ = "facility_memo_tag_links"
 
-    memo_id = Column(Integer, ForeignKey("facility_memos.id", ondelete="CASCADE"), primary_key=True)
+    memo_id = Column(
+        Integer, ForeignKey("facility_memos.id", ondelete="CASCADE"), primary_key=True
+    )
     tag_id = Column(Integer, ForeignKey("memo_tags.id"), primary_key=True)
 
 
 class FacilityMemoLock(Base):
     __tablename__ = "facility_memo_locks"
 
-    memo_id = Column(Integer, ForeignKey("facility_memos.id", ondelete="CASCADE"), primary_key=True)
+    memo_id = Column(
+        Integer, ForeignKey("facility_memos.id", ondelete="CASCADE"), primary_key=True
+    )
     locked_by = Column(Text)
     locked_at = Column(TIMESTAMP, server_default="now()")
+    ip_address = Column(Text)
 
     memo = relationship("FacilityMemo", back_populates="lock")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -7,6 +7,7 @@ class ContactInfo(BaseModel):
     value: str
     comment: Optional[str] = None
 
+
 class FunctionCategoryBase(BaseModel):
     id: int
     name: str
@@ -31,6 +32,7 @@ class FunctionBase(BaseModel):
 
     class Config:
         from_attributes = True
+
 
 class FunctionCreate(BaseModel):
     """機能マスタ登録用のスキーマ
@@ -59,6 +61,7 @@ class FacilityFunctionEntryBase(BaseModel):
     class Config:
         from_attributes = True
 
+
 class MedicalFacilityBase(BaseModel):
     short_name: str
     official_name: Optional[str]
@@ -76,12 +79,14 @@ class MedicalFacilityBase(BaseModel):
             raise ValueError("略名が未入力のため登録できません")
         return v
 
+
 class MedicalFacility(MedicalFacilityBase):
     id: int
     functions: List[FacilityFunctionEntryBase] = []
 
     class Config:
         from_attributes = True
+
 
 class MedicalFacilityUpdate(BaseModel):
     short_name: Optional[str] = None
@@ -100,17 +105,20 @@ class MedicalFacilityUpdate(BaseModel):
             raise ValueError("略名が未入力のため登録できません")
         return v
 
+
 class FacilityFunctionEntryCreate(BaseModel):
     facility_id: int
     function_id: int
     selected_values: Optional[List[str]] = []
     remarks: Optional[str] = None
 
+
 class FunctionUpdate(BaseModel):
     """
     機能マスタ更新用のスキーマ。
     すべてOptionalなので部分更新にも対応可能。
     """
+
     name: Optional[str] = None
     description: Optional[str] = None
     memo: Optional[str] = None
@@ -124,11 +132,13 @@ class FunctionUpdate(BaseModel):
             raise ValueError("名称が未入力のため登録できません")
         return v
 
+
 class FacilityFunctionEntryUpdate(BaseModel):
     """
     施設機能割り当て情報の更新用スキーマ。
     すべてOptionalで部分更新に対応。
     """
+
     facility_id: Optional[int] = None
     function_id: Optional[int] = None
     selected_values: Optional[List[str]] = None
@@ -215,6 +225,7 @@ class FacilityMemoVersionBase(BaseModel):
     version_no: int
     content: Optional[str]
     created_at: Optional[datetime]
+    ip_address: Optional[str]
 
     class Config:
         from_attributes = True
@@ -224,8 +235,7 @@ class FacilityMemoLockBase(BaseModel):
     memo_id: int
     locked_by: Optional[str]
     locked_at: Optional[datetime]
+    ip_address: Optional[str]
 
     class Config:
         from_attributes = True
-
-

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -69,6 +69,7 @@ CREATE TABLE facility_memo_versions (
     version_no INTEGER NOT NULL,
     content TEXT,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    ip_address TEXT,
     UNIQUE (memo_id, version_no)
 );
 
@@ -81,5 +82,6 @@ CREATE TABLE facility_memo_tag_links (
 CREATE TABLE facility_memo_locks (
     memo_id INTEGER PRIMARY KEY REFERENCES facility_memos(id) ON DELETE CASCADE,
     locked_by TEXT,
-    locked_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+    locked_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    ip_address TEXT
 );

--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -129,12 +129,13 @@ export default function MemoApp({ facilityId, facilityName }: Props) {
 
   const handleEdit = (memo: MemoItem) => {
     lockMemo(memo.id)
-      .then((res) => {
+      .then(async (res) => {
         if (res.ok) {
           setEditing({ ...memo });
           setEditingReadOnly(false);
         } else {
-          alert('他のユーザーが編集中です');
+          const data = await res.json().catch(() => null);
+          alert(data?.detail || '他のユーザーが編集中です');
         }
       })
       .catch(() => alert('ロック取得に失敗しました'));


### PR DESCRIPTION
## Summary
- store IP addresses for memo history and locks
- surface IP address in lock conflict responses
- display lock holder IP in frontend memo editor alert

## Testing
- `python -m py_compile backend/app/models.py backend/app/schemas.py backend/app/routers/memo.py`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686f807af5a48328b3fb14cc51ad7017