### PR TITLE
Fix history dialog closing when viewing memo versions

### DIFF
--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -31,7 +31,10 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
 
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-[70]">
+    <div
+      className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-[70]"
+      onMouseDown={(e) => e.stopPropagation()}
+    >
       <div className="bg-white w-11/12 max-w-3xl p-4 rounded shadow flex flex-col h-[80%]">
         <div className="flex-1 flex flex-col md:flex-row gap-4">
           <div className="flex-1 flex flex-col">


### PR DESCRIPTION
## Summary
- stop pointer events from closing the underlying history dialog when viewing a memo version

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68704a065f408328b5ac8c6f96e533ad