### PR TITLE
Fix memo lock user identification

### DIFF
--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -32,7 +32,17 @@ interface FacilityMemoResponse {
 
 const initialMemos: MemoItem[] = [];
 const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8001';
-const currentUser = 'user1';
+
+const getCurrentUser = (): string => {
+  let user = localStorage.getItem('memoUser');
+  if (!user) {
+    user = Math.random().toString(36).slice(2);
+    localStorage.setItem('memoUser', user);
+  }
+  return user;
+};
+
+const currentUser = getCurrentUser();
 
 const getCookie = (name: string): string | null => {
   const match = document.cookie


### PR DESCRIPTION
## Summary
- assign a unique per-browser ID for memo lock operations

## Testing
- `npm install`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6870511c193883289c579e1edab37fe6