### PR TITLE
Fix memo history filter end date

### DIFF
--- a/my-medical-app/src/memo/MemoHistoryModal.tsx
+++ b/my-medical-app/src/memo/MemoHistoryModal.tsx
@@ -37,7 +37,7 @@ export default function MemoHistoryModal({ memoId, isOpen, onClose, onRestore, o
     if (!isOpen) return;
     const params = new URLSearchParams();
     if (start) params.append('start_date', start);
-    if (end) params.append('end_date', end);
+    if (end) params.append('end_date', `${end}T23:59`);
     if (ip) params.append('ip_address', ip);
     fetch(`${apiBase}/memos/${memoId}/versions?${params.toString()}`)
       .then((res) => res.json())


### PR DESCRIPTION
## Summary
- update MemoHistoryModal to send end date at 23:59 when filtering

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870d7378b4483289e67eeaa81ad5118