### PR TITLE
Enable colored tags

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -93,6 +93,7 @@ class MemoTag(Base):
     id = Column(Integer, primary_key=True)
     name = Column(Text, nullable=False)
     remark = Column(Text)
+    color = Column(Text)
     is_deleted = Column(Boolean, default=False)
 
     memos = relationship(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -171,6 +171,7 @@ class MemoTagBase(BaseModel):
     id: int
     name: str
     remark: Optional[str]
+    color: Optional[str]
     is_deleted: bool
 
     class Config:
@@ -180,6 +181,7 @@ class MemoTagBase(BaseModel):
 class MemoTagCreate(BaseModel):
     name: str
     remark: Optional[str] = None
+    color: Optional[str] = None
 
     @validator("name")
     def validate_name(cls, v: str) -> str:

--- a/my-medical-app/src/components/MultiSelect.tsx
+++ b/my-medical-app/src/components/MultiSelect.tsx
@@ -4,6 +4,7 @@ import { Fragment, useState } from 'react';
 export interface Option {
   value: number;
   label: string;
+  color?: string;
 }
 
 interface Props {
@@ -34,9 +35,19 @@ export default function MultiSelect({
     }
   };
 
-  const selectedLabels = selected
-    .map((v) => options.find((o) => o.value === v)?.label)
-    .filter(Boolean);
+  const selectedOptions = selected
+    .map((v) => options.find((o) => o.value === v))
+    .filter(Boolean) as Option[];
+
+  const getContrast = (hex?: string) => {
+    if (!hex) return '#000';
+    const c = hex.replace('#', '');
+    const r = parseInt(c.substring(0, 2), 16);
+    const g = parseInt(c.substring(2, 4), 16);
+    const b = parseInt(c.substring(4, 6), 16);
+    const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+    return yiq >= 128 ? '#000' : '#fff';
+  };
 
   return (
     <Listbox value={selected} onChange={onChange} multiple disabled={disabled}>
@@ -46,14 +57,18 @@ export default function MultiSelect({
             onClick={() => !disabled && setOpen((o) => !o)}
             className={`w-full border rounded px-2 py-1 text-left ${disabled ? 'bg-gray-100 cursor-not-allowed' : ''}`}
           >
-            {selectedLabels.length ? (
+            {selectedOptions.length ? (
               <div className="flex flex-wrap gap-1">
-                {selectedLabels.map((label) => (
+                {selectedOptions.map((opt) => (
                   <span
-                    key={label}
-                    className="bg-blue-100 text-blue-800 px-1 rounded text-sm"
+                    key={opt.value}
+                    className="px-1 rounded text-sm"
+                    style={{
+                      backgroundColor: opt.color || '#bfdbfe',
+                      color: getContrast(opt.color),
+                    }}
                   >
-                    {label}
+                    {opt.label}
                   </span>
                 ))}
               </div>
@@ -85,6 +100,12 @@ export default function MultiSelect({
                         checked={selected.includes(opt.value)}
                         readOnly
                       />
+                      {opt.color && (
+                        <span
+                          className="w-3 h-3 inline-block rounded"
+                          style={{ backgroundColor: opt.color }}
+                        />
+                      )}
                       <span>{opt.label}</span>
                     </li>
                   )}

--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -18,6 +18,7 @@ export interface MemoTag {
   id: number;
   name: string;
   remark?: string;
+  color?: string;
   is_deleted: boolean;
 }
 

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -23,7 +23,11 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
   const [content, setContent] = useState(memo.content);
   const [tags, setTags] = useState<number[]>(memo.tag_ids);
 
-  const options: Option[] = tagOptions.map((t) => ({ value: t.id, label: t.name }));
+  const options: Option[] = tagOptions.map((t) => ({
+    value: t.id,
+    label: t.name,
+    color: t.color,
+  }));
 
   const handleSave = () => {
     if (readOnly) return;

--- a/my-medical-app/src/memo/MemoList.tsx
+++ b/my-medical-app/src/memo/MemoList.tsx
@@ -33,7 +33,11 @@ export default function MemoList({
   onCreate,
   className = '',
 }: Props) {
-  const options: Option[] = tagOptions.map((t) => ({ value: t.id, label: t.name }));
+  const options: Option[] = tagOptions.map((t) => ({
+    value: t.id,
+    label: t.name,
+    color: t.color,
+  }));
   return (
     <div className={`overflow-y-auto p-2 space-y-2 ${className}`}>
       <div className="flex items-center justify-between mb-2">

--- a/my-medical-app/src/memo/MemoTagManager.tsx
+++ b/my-medical-app/src/memo/MemoTagManager.tsx
@@ -20,6 +20,7 @@ export default function MemoTagManager() {
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [name, setName] = useState('');
   const [remark, setRemark] = useState('');
+  const [color, setColor] = useState('#bfdbfe');
   const [editing, setEditing] = useState<MemoTag | null>(null);
 
   const fetchTags = () => {
@@ -55,10 +56,11 @@ export default function MemoTagManager() {
     fetch(url, {
       method,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, remark }),
+      body: JSON.stringify({ name, remark, color }),
     }).then(() => {
       setName('');
       setRemark('');
+      setColor('#bfdbfe');
       setEditing(null);
       fetchTags();
     });
@@ -76,12 +78,14 @@ export default function MemoTagManager() {
     setEditing(tag);
     setName(tag.name);
     setRemark(tag.remark || '');
+    setColor(tag.color || '#bfdbfe');
   };
 
   const cancelEdit = () => {
     setEditing(null);
     setName('');
     setRemark('');
+    setColor('#bfdbfe');
   };
 
   const updateOrder = (newTags: MemoTag[]) => {
@@ -114,6 +118,12 @@ export default function MemoTagManager() {
           placeholder="備考"
           className="border p-1"
         />
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="border p-1 w-16 h-8"
+        />
         <button className="bg-blue-500 text-white px-2 py-1 rounded" onClick={handleSubmit}>
           {editing ? '更新' : '追加'}
         </button>
@@ -129,6 +139,7 @@ export default function MemoTagManager() {
             <th className="border p-1">ID</th>
             <th className="border p-1">名前</th>
             <th className="border p-1">備考</th>
+            <th className="border p-1">色</th>
             <th className="border p-1">操作</th>
           </tr>
         </thead>
@@ -145,6 +156,14 @@ export default function MemoTagManager() {
               <td className="border p-1 text-center">{tag.id}</td>
               <td className="border p-1">{tag.name}</td>
               <td className="border p-1">{tag.remark}</td>
+              <td className="border p-1">
+                {tag.color && (
+                  <span
+                    className="inline-block w-4 h-4 rounded"
+                    style={{ backgroundColor: tag.color }}
+                  />
+                )}
+              </td>
               <td className="border p-1 space-x-1">
                 <button className="px-1 bg-green-500 text-white" onClick={() => startEdit(tag)}>
                   編集

--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -13,10 +13,19 @@ interface Props {
 
 export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, onShowHistory }: Props) {
   if (!memo) return <div className="flex-1 p-4">メモを選択してください</div>;
-  const tags = memo.tag_ids
-    .map((id) => tagOptions.find((t) => t.id === id)?.name)
-    .filter(Boolean)
-    .join(', ');
+  const tagObjs = memo.tag_ids
+    .map((id) => tagOptions.find((t) => t.id === id))
+    .filter(Boolean) as MemoTag[];
+
+  const getContrast = (hex?: string) => {
+    if (!hex) return '#000';
+    const c = hex.replace('#', '');
+    const r = parseInt(c.substring(0, 2), 16);
+    const g = parseInt(c.substring(2, 4), 16);
+    const b = parseInt(c.substring(4, 6), 16);
+    const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+    return yiq >= 128 ? '#000' : '#fff';
+  };
   return (
     <div className="flex-1 p-4 overflow-y-auto">
       <div className="flex justify-end mb-2 space-x-2">
@@ -42,7 +51,19 @@ export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, o
       <div className="prose max-w-none">
         <Markdown remarkPlugins={[remarkGfm, remarkBreaks]}>{memo.content}</Markdown>
       </div>
-      {tags && <div className="mt-2 text-sm text-gray-600">タグ: {tags}</div>}
+      {tagObjs.length > 0 && (
+        <div className="mt-2 text-sm flex flex-wrap gap-1">
+          {tagObjs.map((t) => (
+            <span
+              key={t.id}
+              className="px-1 rounded"
+              style={{ backgroundColor: t.color || '#bfdbfe', color: getContrast(t.color) }}
+            >
+              {t.name}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow color attribute for memo tags
- display colored badges in tag manager and memo viewer
- show tag colors when selecting tags in MultiSelect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870de0f8e0883289754e72efb9f59b3