### PR TITLE
Fix memo list tag dropdown

### DIFF
--- a/my-medical-app/src/memo/MemoList.tsx
+++ b/my-medical-app/src/memo/MemoList.tsx
@@ -39,7 +39,7 @@ export default function MemoList({
     color: t.color,
   }));
   return (
-    <div className={`overflow-y-auto p-2 space-y-2 ${className}`}>
+    <div className={`flex flex-col h-full p-2 space-y-2 ${className}`}>
       <div className="flex items-center justify-between mb-2">
         <ImeInput
           type="text"
@@ -71,7 +71,8 @@ export default function MemoList({
       >
         ＋新規作成
       </button>
-      <ul className="space-y-1">
+      <div className="flex-1 overflow-y-auto">
+        <ul className="space-y-1">
         {memos.map((m) => (
           <li
             key={m.id}
@@ -85,6 +86,7 @@ export default function MemoList({
           </li>
         ))}
       </ul>
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep memo list container scrollable without clipping dropdown

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6871da28f20483289356c8195dd8ce35