### PR TITLE
Add note_images table

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,6 +10,8 @@ from sqlalchemy import (
     JSON,
     TIMESTAMP,
 )
+from sqlalchemy.dialects.postgresql import BYTEA
+import uuid
 from sqlalchemy.orm import relationship
 from .database import Base
 
@@ -167,3 +169,17 @@ class FacilityMemoLock(Base):
     ip_address = Column(Text)
 
     memo = relationship("FacilityMemo", back_populates="lock")
+
+
+# 画像データ保存テーブル
+class NoteImage(Base):
+    __tablename__ = "note_images"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    memo_id = Column(Integer, ForeignKey("facility_memos.id", ondelete="CASCADE"))
+    file_name = Column(Text, nullable=False)
+    mime_type = Column(Text, nullable=False)
+    data = Column(BYTEA, nullable=False)
+    created_at = Column(TIMESTAMP, server_default="now()")
+
+    memo = relationship("FacilityMemo", backref="images")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -242,3 +242,21 @@ class FacilityMemoLockBase(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class NoteImageBase(BaseModel):
+    id: str
+    memo_id: int
+    file_name: str
+    mime_type: str
+    created_at: Optional[datetime]
+
+    class Config:
+        from_attributes = True
+
+
+class NoteImageCreate(BaseModel):
+    memo_id: int
+    file_name: str
+    mime_type: str
+

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -86,3 +86,12 @@ CREATE TABLE facility_memo_locks (
     locked_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     ip_address TEXT
 );
+
+CREATE TABLE note_images (
+    id UUID PRIMARY KEY,
+    memo_id INTEGER REFERENCES facility_memos(id) ON DELETE CASCADE,
+    file_name TEXT NOT NULL,
+    mime_type TEXT NOT NULL,
+    data BYTEA NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- create `note_images` table in SQL schema for storing images in bytea format
- add `NoteImage` ORM model with UUID primary key and binary data
- define pydantic schemas for note images

## Testing
- `python -m py_compile backend/app/models.py backend/app/schemas.py`
- `python -m backend.app.reset_db` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6871dc90a5108328aada06a4816bb91d