### PR TITLE
Implement front-end image uploads

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,14 @@
 from fastapi import FastAPI
 from .database import Base, engine
-from .routers import facility, function, facility_function_entry, function_category, memo, memo_tag
+from .routers import (
+    facility,
+    function,
+    facility_function_entry,
+    function_category,
+    memo,
+    memo_tag,
+    note_image,
+)
 from fastapi.middleware.cors import CORSMiddleware
 
 # DB初期化（テーブル作成）
@@ -24,3 +32,4 @@ app.include_router(facility_function_entry.router)
 app.include_router(function_category.router)
 app.include_router(memo.router)
 app.include_router(memo_tag.router)
+app.include_router(note_image.router)

--- a/backend/app/routers/note_image.py
+++ b/backend/app/routers/note_image.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException, Response
+from sqlalchemy.orm import Session
+from .. import database, models, schemas
+
+router = APIRouter(prefix="/images", tags=["images"])
+
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("/", response_model=schemas.NoteImageBase)
+async def upload_image(
+    memo_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    data = await file.read()
+    img = models.NoteImage(
+        memo_id=memo_id,
+        file_name=file.filename,
+        mime_type=file.content_type or "application/octet-stream",
+        data=data,
+    )
+    db.add(img)
+    db.commit()
+    db.refresh(img)
+    return img
+
+
+@router.get("/{image_id}")
+def get_image(image_id: str, db: Session = Depends(get_db)):
+    img = db.query(models.NoteImage).filter(models.NoteImage.id == image_id).first()
+    if not img:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return Response(content=img.data, media_type=img.mime_type)
+


### PR DESCRIPTION
## Summary
- create `note_image` router for image upload and retrieval
- hook new router into FastAPI app
- support dropping/pasting/choosing files in memo editor

## Testing
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68744548cfa08328baefb0b0898c6141