### PR TITLE
Fix NoteImage ID type

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, validator
 from typing import Optional, List
 from datetime import datetime
+from uuid import UUID
 
 
 class ContactInfo(BaseModel):
@@ -245,7 +246,7 @@ class FacilityMemoLockBase(BaseModel):
 
 
 class NoteImageBase(BaseModel):
-    id: str
+    id: UUID
     memo_id: int
     file_name: str
     mime_type: str


### PR DESCRIPTION
## Summary
- update NoteImageBase schema to use UUID for id

## Testing
- `python - <<'PY'
from pydantic import BaseModel
from uuid import UUID
class NoteImageBase(BaseModel):
    id: UUID

print(NoteImageBase(id=UUID('4a5a9d7f-049a-44f4-91fa-479ca4aaf3f3')).json())
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6874516e341883288bbd9443cbd42f9d