### PR TITLE
Fix NoteImage ID type

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,7 +10,7 @@ from sqlalchemy import (
     JSON,
     TIMESTAMP,
 )
-from sqlalchemy.dialects.postgresql import BYTEA
+from sqlalchemy.dialects.postgresql import BYTEA, UUID as PG_UUID
 import uuid
 from sqlalchemy.orm import relationship
 from .database import Base
@@ -175,7 +175,7 @@ class FacilityMemoLock(Base):
 class NoteImage(Base):
     __tablename__ = "note_images"
 
-    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     memo_id = Column(Integer, ForeignKey("facility_memos.id", ondelete="CASCADE"))
     file_name = Column(Text, nullable=False)
     mime_type = Column(Text, nullable=False)

--- a/backend/app/routers/note_image.py
+++ b/backend/app/routers/note_image.py
@@ -37,7 +37,7 @@ async def upload_image(
     db.add(img)
     db.commit()
     db.refresh(img)
-    return img
+    return schemas.NoteImageBase.from_orm(img)
 
 
 @router.get("/{image_id}")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, validator
 from typing import Optional, List
 from datetime import datetime
+from uuid import UUID
 
 
 class ContactInfo(BaseModel):
@@ -245,7 +246,7 @@ class FacilityMemoLockBase(BaseModel):
 
 
 class NoteImageBase(BaseModel):
-    id: str
+    id: UUID
     memo_id: int
     file_name: str
     mime_type: str
@@ -253,6 +254,7 @@ class NoteImageBase(BaseModel):
 
     class Config:
         from_attributes = True
+        orm_mode = True
 
 
 class NoteImageCreate(BaseModel):


### PR DESCRIPTION
## Summary
- update NoteImageBase schema to use orm mode
- change NoteImage.id column to use PostgreSQL UUID
- return NoteImageBase from ORM object

## Testing
- `python - <<'PY'
from uuid import uuid4
from backend.app.schemas import NoteImageBase
class Dummy:
    def __init__(self, id):
        self.id=id
        self.memo_id=1
        self.file_name='a.jpg'
        self.mime_type='image/jpeg'
        self.created_at=None

print(NoteImageBase.from_orm(Dummy(uuid4())).json())
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6874516e341883288bbd9443cbd42f9d