### PR TITLE
Implement image modal view

### DIFF
--- a/my-medical-app/src/components/ImageModal.tsx
+++ b/my-medical-app/src/components/ImageModal.tsx
@@ -1,0 +1,73 @@
+import { Dialog, Transition } from '@headlessui/react';
+import { Fragment, useState } from 'react';
+
+interface Props {
+  src: string;
+  alt?: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ImageModal({ src, alt = '', isOpen, onClose }: Props) {
+  const [scale, setScale] = useState(1);
+  const [rotate, setRotate] = useState(0);
+
+  const reset = () => {
+    setScale(1);
+    setRotate(0);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const zoomIn = () => setScale((s) => s + 0.1);
+  const zoomOut = () => setScale((s) => Math.max(0.1, s - 0.1));
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-[90]" onClose={handleClose}>
+        <div className="fixed inset-0 bg-black bg-opacity-50" />
+        <div className="fixed inset-0 overflow-y-auto flex items-center justify-center p-4">
+          <Dialog.Panel className="bg-white rounded shadow relative p-4">
+            <button
+              className="absolute top-1 right-1 text-xl leading-none"
+              onClick={handleClose}
+            >
+              ×
+            </button>
+            <div className="flex flex-col items-center">
+              <img
+                src={src}
+                alt={alt}
+                className="max-h-[80vh] max-w-[80vw]"
+                style={{ transform: `scale(${scale}) rotate(${rotate}deg)` }}
+              />
+              <div className="mt-2 flex gap-2">
+                <button className="px-2 py-1 bg-gray-200 rounded" onClick={zoomIn}>
+                  +
+                </button>
+                <button className="px-2 py-1 bg-gray-200 rounded" onClick={zoomOut}>
+                  -
+                </button>
+                <button
+                  className="px-2 py-1 bg-gray-200 rounded"
+                  onClick={() => setRotate((r) => r - 90)}
+                >
+                  ↺
+                </button>
+                <button
+                  className="px-2 py-1 bg-gray-200 rounded"
+                  onClick={() => setRotate((r) => r + 90)}
+                >
+                  ↻
+                </button>
+              </div>
+            </div>
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import ImageModal from '../components/ImageModal';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
@@ -23,6 +24,8 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
   const [title, setTitle] = useState(memo.title);
   const [content, setContent] = useState(memo.content);
   const [tags, setTags] = useState<number[]>(memo.tag_ids);
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [imageAlt, setImageAlt] = useState<string>('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const resizingIdRef = useRef<string | null>(null);
@@ -293,11 +296,14 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
                 remarkPlugins={[remarkGfm, remarkBreaks]}
                 rehypePlugins={[rehypeRaw]}
                 components={{
-                  img({ node, ...props }) {
-                    const id = (props as any)['data-id'] as string | undefined;
-                    const width = parseInt((props.style as React.CSSProperties)?.width as string) || 300;
+                  img(props: React.ImgHTMLAttributes<HTMLImageElement> & { 'data-id'?: string }) {
+                    const id = props['data-id'];
+                    const width =
+                      parseInt((props.style as React.CSSProperties)?.width as string) || 300;
                     return (
-                      <span className="inline-block relative" draggable={!readOnly}
+                      <span
+                        className="inline-block relative"
+                        draggable={!readOnly}
                         onDragStart={(e) => {
                           if (id) {
                             e.dataTransfer.setData('text/image-id', id);
@@ -310,7 +316,14 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
                           }
                         }}
                       >
-                        <img {...props} className="max-w-full" />
+                        <img
+                          {...props}
+                          className="max-w-full cursor-pointer"
+                          onClick={() => {
+                            setImageSrc(props.src || '');
+                            setImageAlt(props.alt as string || '');
+                          }}
+                        />
                         {!readOnly && id && (
                           <span
                             className="absolute w-3 h-3 bg-blue-500 bottom-0 right-0 cursor-se-resize"
@@ -329,6 +342,14 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
               >
                 {content}
               </Markdown>
+              {imageSrc && (
+                <ImageModal
+                  src={imageSrc}
+                  alt={imageAlt}
+                  isOpen={!!imageSrc}
+                  onClose={() => setImageSrc(null)}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -3,6 +3,8 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import rehypeRaw from 'rehype-raw';
+import { useState } from 'react';
+import ImageModal from '../components/ImageModal';
 
 interface Props {
   memo: MemoItem | null;
@@ -13,6 +15,8 @@ interface Props {
 }
 
 export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, onShowHistory }: Props) {
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [imageAlt, setImageAlt] = useState<string>('');
   if (!memo) return <div className="flex-1 p-4">メモを選択してください</div>;
   const tagObjs = memo.tag_ids
     .map((id) => tagOptions.find((t) => t.id === id))
@@ -53,9 +57,33 @@ export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, o
         <Markdown
           remarkPlugins={[remarkGfm, remarkBreaks]}
           rehypePlugins={[rehypeRaw]}
+          components={{
+            img(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+              const src = props.src || '';
+              const alt = props.alt as string | undefined;
+              return (
+                <img
+                  {...props}
+                  className="cursor-pointer max-w-full"
+                  onClick={() => {
+                    setImageSrc(src);
+                    setImageAlt(alt || '');
+                  }}
+                />
+              );
+            },
+          }}
         >
           {memo.content}
         </Markdown>
+        {imageSrc && (
+          <ImageModal
+            src={imageSrc}
+            alt={imageAlt}
+            isOpen={!!imageSrc}
+            onClose={() => setImageSrc(null)}
+          />
+        )}
       </div>
       {tagObjs.length > 0 && (
         <div className="mt-2 text-sm flex flex-wrap gap-1">


### PR DESCRIPTION
## Summary
- add `ImageModal` for zooming and rotating images in a modal
- open image modal from `MemoViewer` and `MemoEditor`
- lint and build pass

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874575082ac832897175e67d11c0bc2