### PR TITLE
Enable scrolling in memo editor

### DIFF
--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -264,7 +264,7 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
             <ImeTextarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
-              className="border p-1 flex-1"
+              className="border p-1 flex-1 overflow-auto"
               disabled={readOnly}
               ref={textareaRef}
               onDragOver={(e) => {


### PR DESCRIPTION
## Summary
- make the editor text area overflow scrollable
- the preview pane already had overflow

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68746ba7d200832886b699cacfdbde9d