### PR TITLE
Restrict memo image resize handle

### DIFF
--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -31,7 +31,7 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
   const resizingIdRef = useRef<string | null>(null);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
-  const resizeDirRef = useRef<'left' | 'right'>('right');
+  const resizeDirRef = useRef<'right'>('right');
   const dragPosRef = useRef(0);
 
   const caretIndexFromPoint = (e: { clientX: number; clientY: number }): number => {
@@ -387,52 +387,17 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
                           }}
                         />
                         {!readOnly && id && (
-                          <>
-                            <span
-                              className="absolute w-3 h-3 bg-blue-500 bottom-0 right-0 cursor-se-resize"
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                startXRef.current = e.clientX;
-                                startWidthRef.current = width;
-                                resizeDirRef.current = 'right';
-                                resizingIdRef.current = id;
-                              }}
-                            />
-                            <span
-                              className="absolute w-3 h-3 bg-blue-500 bottom-0 left-0 cursor-sw-resize"
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                startXRef.current = e.clientX;
-                                startWidthRef.current = width;
-                                resizeDirRef.current = 'left';
-                                resizingIdRef.current = id;
-                              }}
-                            />
-                            <span
-                              className="absolute w-3 h-3 bg-blue-500 top-0 right-0 cursor-ne-resize"
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                startXRef.current = e.clientX;
-                                startWidthRef.current = width;
-                                resizeDirRef.current = 'right';
-                                resizingIdRef.current = id;
-                              }}
-                            />
-                            <span
-                              className="absolute w-3 h-3 bg-blue-500 top-0 left-0 cursor-nw-resize"
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                startXRef.current = e.clientX;
-                                startWidthRef.current = width;
-                                resizeDirRef.current = 'left';
-                                resizingIdRef.current = id;
-                              }}
-                            />
-                          </>
+                          <span
+                            className="absolute w-3 h-3 bg-blue-500 bottom-0 right-0 cursor-se-resize"
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              startXRef.current = e.clientX;
+                              startWidthRef.current = width;
+                              resizeDirRef.current = 'right';
+                              resizingIdRef.current = id;
+                            }}
+                          />
                         )}
                       </span>
                     );


### PR DESCRIPTION
## Summary
- limit resizing handles to bottom-right only
- keep drag-and-drop reposition in preview

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874793280388328a6a112c061ac727b