### PR TITLE
Support shared memos

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -109,10 +109,11 @@ class FacilityMemo(Base):
     __tablename__ = "facility_memos"
 
     id = Column(Integer, primary_key=True)
-    facility_id = Column(Integer, ForeignKey("medical_facility.id"))
+    facility_id = Column(Integer, ForeignKey("medical_facility.id"), nullable=True)
     title = Column(Text, nullable=False)
     content = Column(Text)
     is_deleted = Column(Boolean, default=False)
+    sort_order = Column(Integer, default=0)
     updated_at = Column(TIMESTAMP, server_default="now()")
 
     facility = relationship("MedicalFacility")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -193,10 +193,11 @@ class MemoTagCreate(BaseModel):
 
 class FacilityMemoBase(BaseModel):
     id: int
-    facility_id: int
+    facility_id: Optional[int]
     title: str
     content: Optional[str]
     is_deleted: bool
+    sort_order: int
     updated_at: Optional[datetime]
     tags: List[MemoTagBase] = []
 
@@ -208,6 +209,8 @@ class FacilityMemoCreate(BaseModel):
     title: str
     content: Optional[str] = None
     tag_ids: Optional[List[int]] = None
+    facility_id: Optional[int] = None
+    sort_order: Optional[int] = None
 
     @validator("title")
     def validate_title(cls, v: str) -> str:
@@ -220,6 +223,8 @@ class FacilityMemoUpdate(BaseModel):
     title: Optional[str] = None
     content: Optional[str] = None
     tag_ids: Optional[List[int]] = None
+    facility_id: Optional[int] = None
+    sort_order: Optional[int] = None
 
 
 class FacilityMemoVersionBase(BaseModel):
@@ -243,6 +248,15 @@ class FacilityMemoLockBase(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class MemoOrderItem(BaseModel):
+    id: int
+    sort_order: int
+
+
+class MemoOrderUpdate(BaseModel):
+    orders: List[MemoOrderItem]
 
 
 class NoteImageBase(BaseModel):

--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -1280,6 +1280,15 @@ export default function App() {
             </div>
           )}
         </div>
+        <button
+          className="ml-2 px-3 py-2 bg-gray-200 rounded"
+          onClick={() => {
+            const url = `memo.html?facilityId=0&facilityName=${encodeURIComponent('共通メモ')}`;
+            window.open(url, '_blank');
+          }}
+        >
+          共通メモ
+        </button>
       </div>
 
       <div className="flex-1 overflow-hidden px-4 pt-2 pb-4 flex flex-col">

--- a/my-medical-app/src/memo.tsx
+++ b/my-medical-app/src/memo.tsx
@@ -6,6 +6,7 @@ import './index.css';
 const params = new URLSearchParams(window.location.search);
 const facilityId = Number(params.get('facilityId')) || 0;
 const facilityName = params.get('facilityName') || '';
+const initialSelectedId = params.get('memoId') ? Number(params.get('memoId')) : null;
 
 // ブラウザタブのタイトルを医療機関名に更新
 if (facilityName) {
@@ -14,6 +15,6 @@ if (facilityName) {
 
 createRoot(document.getElementById('memo-root')!).render(
   <React.StrictMode>
-    <MemoApp facilityId={facilityId} facilityName={facilityName} />
+    <MemoApp facilityId={facilityId} facilityName={facilityName} initialSelectedId={initialSelectedId} />
   </React.StrictMode>
 );

--- a/my-medical-app/src/memo/MemoList.tsx
+++ b/my-medical-app/src/memo/MemoList.tsx
@@ -16,6 +16,7 @@ interface Props {
   tagFilter: number[];
   onTagFilterChange: (v: number[]) => void;
   onCreate: () => void;
+  onMove: (id: number, direction: -1 | 1) => void;
   className?: string;
 }
 
@@ -31,6 +32,7 @@ export default function MemoList({
   tagFilter,
   onTagFilterChange,
   onCreate,
+  onMove,
   className = '',
 }: Props) {
   const options: Option[] = tagOptions.map((t) => ({
@@ -73,7 +75,7 @@ export default function MemoList({
       </button>
       <div className="flex-1 overflow-y-auto">
         <ul className="space-y-1">
-        {memos.map((m) => (
+        {memos.map((m, idx) => (
           <li
             key={m.id}
             className={`p-2 border rounded cursor-pointer ${
@@ -81,7 +83,23 @@ export default function MemoList({
             }`}
             onClick={() => onSelect(m.id)}
           >
-            {m.title}
+            <span className="mr-2">{m.title}</span>
+            <button
+              className="ml-2 px-1 text-sm bg-gray-200 rounded"
+              disabled={idx === 0}
+              onClick={(e) => {
+                e.stopPropagation();
+                onMove(m.id, -1);
+              }}
+            >↑</button>
+            <button
+              className="ml-1 px-1 text-sm bg-gray-200 rounded"
+              disabled={idx === memos.length - 1}
+              onClick={(e) => {
+                e.stopPropagation();
+                onMove(m.id, 1);
+              }}
+            >↓</button>
             {m.deleted && <span className="text-xs text-red-500 ml-2">(削除)</span>}
           </li>
         ))}

--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -47,6 +47,17 @@ export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, o
           履歴
         </button>
         <button
+          className="bg-gray-500 text-white px-2 py-1 rounded"
+          onClick={() => {
+            const params = new URLSearchParams(window.location.search);
+            params.set('memoId', String(memo.id));
+            const url = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+            navigator.clipboard.writeText(url);
+          }}
+        >
+          リンクコピー
+        </button>
+        <button
           className="bg-red-500 text-white px-2 py-1 rounded"
           onClick={onToggleDelete}
         >


### PR DESCRIPTION
## Summary
- allow `facility_id` to be optional and keep memo order in database
- add API routes for shared memos and memo reordering
- open shared memo page from the main menu bar
- keep memo selection via URL parameter and add copy-link button
- implement memo reordering in UI

## Testing
- `python3 -m py_compile $(git ls-files 'backend/**/*.py')`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687771314cf48328a9e3f6d675c18016