### PR TITLE
Fix memo link copy in non-secure contexts

### DIFF
--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -52,7 +52,24 @@ export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, o
             const params = new URLSearchParams(window.location.search);
             params.set('memoId', String(memo.id));
             const url = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
-            navigator.clipboard.writeText(url);
+            if (navigator.clipboard && window.isSecureContext) {
+              navigator.clipboard.writeText(url).catch((e) => console.error(e));
+            } else {
+              const textarea = document.createElement('textarea');
+              textarea.value = url;
+              textarea.style.position = 'fixed';
+              textarea.style.top = '-1000px';
+              textarea.style.left = '-1000px';
+              document.body.appendChild(textarea);
+              textarea.focus();
+              textarea.select();
+              try {
+                document.execCommand('copy');
+              } catch (e) {
+                console.error(e);
+              }
+              document.body.removeChild(textarea);
+            }
           }}
         >
           リンクコピー


### PR DESCRIPTION
## Summary
- ensure memo link copy works even when `navigator.clipboard` is unavailable by
  falling back to `document.execCommand('copy')`
- install Node dependencies and run lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68787cfa5b7c83289c4a8505c427deb7