### PR TITLE
Fix merge conflict and retain sticky left columns

### DIFF
--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -1,11 +1,14 @@
 // App.tsx
-import React, { useEffect, useState, Fragment, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useState, Fragment, useRef } from 'react';
 import { Dialog, Transition, Switch } from '@headlessui/react';
 import './App.css';
 import ImeInput from './components/ImeInput';
 import ImeTextarea from './components/ImeTextarea';
 
 const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8001';
+
+// 行ヘッダーとして固定する列グループID
+const STICKY_GROUP_ID = 'facility';
 
 const setCookie = (name: string, value: string) => {
   document.cookie = `${name}=${encodeURIComponent(value)}; path=/`;
@@ -120,6 +123,17 @@ export default function App() {
   const [headerContextMenu, setHeaderContextMenu] = useState<{ x: number; y: number; key: string } | null>(null);
   const [rowContextMenu, setRowContextMenu] = useState<{ x: number; y: number; facility: Facility } | null>(null);
 
+  // 行選択用
+  const [selectedFacilityIds, setSelectedFacilityIds] = useState<number[]>([]);
+  const dragStartIndexRef = useRef<number | null>(null);
+  const dragAddRef = useRef(false);
+  const baseSelectionRef = useRef<number[]>([]);
+  const draggingRef = useRef(false);
+
+  // 固定列のオフセット計算用
+  const headerRefs = useRef<HTMLTableCellElement[]>([]);
+  const [stickyOffsets, setStickyOffsets] = useState<number[]>([]);
+
   // 機能マスタ・カテゴリマスタ用検索/フィルタ
   const [functionListSearchText, setFunctionListSearchText] = useState('');
   const [functionListSearchMode, setFunctionListSearchMode] = useState<'AND' | 'OR'>('AND');
@@ -145,6 +159,17 @@ export default function App() {
     window.addEventListener('click', closeMenus);
     return () => window.removeEventListener('click', closeMenus);
   }, []);
+
+  useLayoutEffect(() => {
+    const widths = headerRefs.current.map((el) => el?.offsetWidth || 0);
+    const offsets: number[] = [];
+    let acc = 0;
+    for (let i = 0; i < widths.length; i++) {
+      offsets[i] = acc;
+      acc += widths[i];
+    }
+    setStickyOffsets(offsets);
+  }, [visibleColumns, visibleGroups, collapsedGroups, functionOrder, facilities]);
 
   const matchesKeywords = (
     text: string,
@@ -177,6 +202,17 @@ export default function App() {
       window.removeEventListener('contextmenu', handleOutside);
     };
   }, [isMenuOpen]);
+
+  useEffect(() => {
+    const handleMouseUp = () => {
+      draggingRef.current = false;
+      dragStartIndexRef.current = null;
+    };
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, []);
 
   // 医療機関編集モーダル用
   const [isFacilityModalOpen, setIsFacilityModalOpen] = useState(false);
@@ -625,6 +661,44 @@ export default function App() {
       })),
   ];
 
+  const visibleColumnInfo = React.useMemo(() => {
+    const list: { key: string; group: string }[] = [];
+    columnGroups.forEach((g) => {
+      if (!visibleGroups[g.id]) return;
+      const colsInGroup = columns.filter(
+        (c) => c.group === g.id && visibleColumns[c.key] && !tempHiddenColumns[c.key],
+      );
+      if (colsInGroup.length === 0) return;
+      if (collapsedGroups[g.id]) {
+        list.push({ key: `${g.id}-collapsed`, group: g.id });
+      } else {
+        colsInGroup.forEach((c) => list.push({ key: c.key, group: g.id }));
+      }
+    });
+    return list;
+  }, [columnGroups, columns, visibleGroups, visibleColumns, collapsedGroups, tempHiddenColumns]);
+
+  const groupPositions = React.useMemo(() => {
+    const pos: Record<string, { start: number; span: number }> = {};
+    let idx = 0;
+    columnGroups.forEach((g) => {
+      if (!visibleGroups[g.id]) return;
+      const colsInGroup = columns.filter(
+        (c) => c.group === g.id && visibleColumns[c.key] && !tempHiddenColumns[c.key],
+      );
+      if (colsInGroup.length === 0) return;
+      const span = collapsedGroups[g.id] ? 1 : colsInGroup.length;
+      pos[g.id] = { start: idx, span };
+      idx += span;
+    });
+    return pos;
+  }, [columnGroups, columns, visibleGroups, visibleColumns, collapsedGroups, tempHiddenColumns]);
+
+  const stickyColumnCount = React.useMemo(() => {
+    const pos = groupPositions[STICKY_GROUP_ID];
+    return pos ? pos.start + pos.span : 0;
+  }, [groupPositions]);
+
   const searchTargetOptions = [
     { key: 'id', label: 'ID' },
     { key: 'short_name', label: '略名' },
@@ -716,6 +790,65 @@ export default function App() {
 
   const handleHideFacility = (id: number) => {
     setVisibleFacilities((prev) => ({ ...prev, [id]: false }));
+  };
+
+  const handleRowMouseDown = (
+    e: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
+    index: number,
+    id: number,
+  ) => {
+    if (e.button !== 0) return;
+    draggingRef.current = true;
+    dragStartIndexRef.current = index;
+    dragAddRef.current = e.ctrlKey;
+    baseSelectionRef.current = selectedFacilityIds;
+    if (!e.ctrlKey) {
+      setSelectedFacilityIds([id]);
+    }
+  };
+
+  const handleRowMouseEnter = (
+    index: number,
+  ) => {
+    if (!draggingRef.current || dragStartIndexRef.current === null) return;
+    const start = dragStartIndexRef.current;
+    const ids = displayFacilities
+      .slice(Math.min(start, index), Math.max(start, index) + 1)
+      .map((f) => f.id);
+    if (dragAddRef.current) {
+      setSelectedFacilityIds(
+        Array.from(new Set([...baseSelectionRef.current, ...ids])),
+      );
+    } else {
+      setSelectedFacilityIds(ids);
+    }
+  };
+
+  const handleRowMouseUp = (
+    index: number,
+    id: number,
+  ) => {
+    if (!draggingRef.current) return;
+    const start = dragStartIndexRef.current ?? index;
+    const ids = displayFacilities
+      .slice(Math.min(start, index), Math.max(start, index) + 1)
+      .map((f) => f.id);
+    if (dragAddRef.current) {
+      if (start === index && ids.length === 1) {
+        const base = baseSelectionRef.current;
+        const exists = base.includes(id);
+        const newSel = exists ? base.filter((v) => v !== id) : [...base, id];
+        setSelectedFacilityIds(newSel);
+      } else {
+        setSelectedFacilityIds(
+          Array.from(new Set([...baseSelectionRef.current, ...ids])),
+        );
+      }
+    } else {
+      setSelectedFacilityIds(ids);
+    }
+    draggingRef.current = false;
+    dragStartIndexRef.current = null;
   };
 
   const handleRightClick = (
@@ -1192,6 +1325,8 @@ export default function App() {
       ),
     );
 
+  headerRefs.current = [];
+
   return (
     <div className="bg-gray-100 h-screen p-0 overflow-hidden flex flex-col">
       {notification && (
@@ -1349,21 +1484,24 @@ export default function App() {
           <thead className="sticky top-0 z-10 bg-gray-200">
             <tr>
               {columnGroups.map((g) => {
-                if (!visibleGroups[g.id]) return null;
-                const colsInGroup = columns.filter(
-                  (c) =>
-                    c.group === g.id &&
-                    visibleColumns[c.key] &&
-                    !tempHiddenColumns[c.key],
-                );
-                if (colsInGroup.length === 0) return null;
-                const span = collapsedGroups[g.id] ? 1 : colsInGroup.length;
+                const pos = groupPositions[g.id];
+                if (!visibleGroups[g.id] || !pos) return null;
+                const style: React.CSSProperties | undefined =
+                  pos.start < stickyColumnCount
+                    ? ({
+                        position: 'sticky',
+                        left: stickyOffsets[pos.start] || 0,
+                        zIndex: 5,
+                        background: '#e5e7eb',
+                      } as React.CSSProperties)
+                    : undefined;
                 return (
                   <th
                     key={g.id}
-                    colSpan={span}
+                    colSpan={pos.span}
                     className="border px-2 cursor-pointer"
                     onClick={() => toggleCollapse(g.id)}
+                    style={style}
                   >
                     <div className="flex items-center justify-between">
                       <span>{g.label}</span>
@@ -1379,156 +1517,199 @@ export default function App() {
               })}
             </tr>
             <tr className="text-left">
-              {columnGroups.map((g) => {
-                if (!visibleGroups[g.id]) return null;
-                const colsInGroup = columns.filter(
-                  (c) =>
-                    c.group === g.id &&
-                    visibleColumns[c.key] &&
-                    !tempHiddenColumns[c.key],
-                );
-                if (colsInGroup.length === 0) return null;
-                if (collapsedGroups[g.id]) {
-                  return (
-                    <th key={`${g.id}-collapsed`} className="py-2 px-4 border whitespace-nowrap"></th>
-                  );
-                }
-                return colsInGroup.map((col) => {
-                  const isFunc = col.key.startsWith('func_');
-                  const memo = isFunc
-                    ?
-                        allFunctions.find(
-                          (f) => f.id === parseInt(col.key.replace('func_', ''))
-                        )?.memo || ''
-                    : '';
+              {visibleColumnInfo.map((info, idx) => {
+                if (info.key.endsWith('-collapsed')) {
                   return (
                     <th
-                      key={col.key}
-                      className={
-                        'py-2 px-4 border cursor-pointer whitespace-nowrap' +
-                        (isFunc && memo ? ' tooltip-container' : '')
+                      ref={(el) => {
+                        if (el) headerRefs.current[idx] = el;
+                      }}
+                      key={info.key}
+                      className="py-2 px-4 border whitespace-nowrap"
+                      style={
+                        idx < stickyColumnCount
+                          ? ({
+                              position: 'sticky',
+                              left: stickyOffsets[idx] || 0,
+                              zIndex: 5,
+                              background: '#e5e7eb',
+                            } as React.CSSProperties)
+                          : undefined
                       }
-                      onClick={() => handleSort(col.key)}
-                      onContextMenu={(e) => handleHeaderContextMenu(e, col.key)}
-                      data-tooltip={isFunc && memo ? memo : undefined}
-                    >
-                      {col.label}{' '}
-                      {sortKey === col.key && sortOrder !== 'none' &&
-                        (sortOrder === 'asc' ? '▲' : '▼')}
-                    </th>
+                    ></th>
                   );
-                });
+                }
+                const col = columns.find((c) => c.key === info.key)!;
+                const isFunc = col.key.startsWith('func_');
+                const memo = isFunc
+                  ?
+                      allFunctions.find(
+                        (f) => f.id === parseInt(col.key.replace('func_', '')),
+                      )?.memo || ''
+                  : '';
+                return (
+                  <th
+                    ref={(el) => {
+                      if (el) headerRefs.current[idx] = el;
+                    }}
+                    key={col.key}
+                    className={
+                      'py-2 px-4 border cursor-pointer whitespace-nowrap' +
+                      (isFunc && memo ? ' tooltip-container' : '')
+                    }
+                    onClick={() => handleSort(col.key)}
+                    onContextMenu={(e) => handleHeaderContextMenu(e, col.key)}
+                    data-tooltip={isFunc && memo ? memo : undefined}
+                    style={
+                      idx < stickyColumnCount
+                        ? ({
+                            position: 'sticky',
+                            left: stickyOffsets[idx] || 0,
+                            zIndex: 5,
+                            background: '#e5e7eb',
+                          } as React.CSSProperties)
+                        : undefined
+                    }
+                  >
+                    {col.label}{' '}
+                    {sortKey === col.key && sortOrder !== 'none' &&
+                      (sortOrder === 'asc' ? '▲' : '▼')}
+                  </th>
+                );
               })}
             </tr>
           </thead>
           <tbody>
-            {displayFacilities.map((facility) => (
-              <tr key={facility.id} className="hover:bg-gray-50">
-                {columnGroups.map((g) => {
-                  if (!visibleGroups[g.id]) return null;
-                  const colsInGroup = columns.filter(
-                    (c) =>
-                      c.group === g.id &&
-                      visibleColumns[c.key] &&
-                      !tempHiddenColumns[c.key],
-                  );
-                  if (colsInGroup.length === 0) return null;
-                  if (collapsedGroups[g.id]) {
+            {displayFacilities.map((facility, rowIdx) => (
+              <tr
+                key={facility.id}
+                className={`hover:bg-gray-50 cursor-pointer select-none ${
+                  selectedFacilityIds.includes(facility.id) ? 'bg-blue-100' : ''
+                }`}
+                onMouseDown={(e) => handleRowMouseDown(e, rowIdx, facility.id)}
+                onMouseEnter={() => handleRowMouseEnter(rowIdx)}
+                onMouseUp={() => handleRowMouseUp(rowIdx, facility.id)}
+              >
+                {visibleColumnInfo.map((info, idx) => {
+                  if (info.key.endsWith('-collapsed')) {
                     return (
                       <td
-                        key={`${facility.id}-${g.id}`}
+                        key={`${facility.id}-${info.key}`}
                         className="py-2 px-4 border"
+                        style={
+                          idx < stickyColumnCount
+                            ? ({
+                                position: 'sticky',
+                                left: stickyOffsets[idx] || 0,
+                                background: '#fff',
+                                zIndex: 2,
+                              } as React.CSSProperties)
+                            : undefined
+                        }
                       ></td>
                     );
                   }
-                  return colsInGroup.map((col) => {
-                    if (col.key.startsWith('func_')) {
-                      const funcId = parseInt(col.key.replace('func_', ''));
-                      const fEntry = facility.functions.find(
-                        (f) => f.function.id === funcId
-                      );
-                      const remarks = fEntry?.remarks || '';
-                      return (
-                        <td
-                          key={col.key}
-                          className={
-                            'py-2 px-4 border whitespace-nowrap' +
-                            (remarks ? ' tooltip-container' : '')
-                          }
-                          data-tooltip={remarks || undefined}
-                          onContextMenu={(e) =>
-                            handleRightClick(e, facility.id, funcId)
-                          }
-                        >
-                          {fEntry ? (
-                            <div className="flex flex-col">
-                              {fEntry.selected_values.map((v, i) => (
-                                <div key={i}>{v}</div>
+                  const col = columns.find((c) => c.key === info.key)!;
+                  if (col.key.startsWith('func_')) {
+                    const funcId = parseInt(col.key.replace('func_', ''));
+                    const fEntry = facility.functions.find(
+                      (f) => f.function.id === funcId,
+                    );
+                    const remarks = fEntry?.remarks || '';
+                    return (
+                      <td
+                        key={col.key}
+                        className={
+                          'py-2 px-4 border whitespace-nowrap' +
+                          (remarks ? ' tooltip-container' : '')
+                        }
+                        data-tooltip={remarks || undefined}
+                        onContextMenu={(e) => handleRightClick(e, facility.id, funcId)}
+                        style={
+                          idx < stickyColumnCount
+                            ? ({
+                                position: 'sticky',
+                                left: stickyOffsets[idx] || 0,
+                                background: '#fff',
+                                zIndex: 2,
+                              } as React.CSSProperties)
+                            : undefined
+                        }
+                      >
+                        {fEntry ? (
+                          <div className="flex flex-col">
+                            {fEntry.selected_values.map((v, i) => (
+                              <div key={i}>{v}</div>
+                            ))}
+                            {showFunctionRemarks && fEntry.remarks && (
+                              (() => {
+                                const lines = fEntry.remarks.split('\n');
+                                const display = lines.slice(0, 2);
+                                const truncated = lines.length > 2;
+                                return (
+                                  <>
+                                    {display.map((l, i) => (
+                                      <div key={i}>{l}</div>
+                                    ))}
+                                    {truncated && <div>...</div>}
+                                  </>
+                                );
+                              })()
+                            )}
+                          </div>
+                        ) : (
+                          '-'
+                        )}
+                      </td>
+                    );
+                  }
+                  const val = (facility as unknown as Record<string, unknown>)[col.key];
+                  return (
+                    <td
+                      key={col.key}
+                      className="py-2 px-4 border whitespace-nowrap"
+                      onContextMenu={(e) => handleFacilityCellRightClick(e, facility)}
+                      style={
+                        idx < stickyColumnCount
+                          ? ({
+                              position: 'sticky',
+                              left: stickyOffsets[idx] || 0,
+                              background: '#fff',
+                              zIndex: 2,
+                            } as React.CSSProperties)
+                          : undefined
+                      }
+                    >
+                      {Array.isArray(val) ? (
+                        <div className="flex flex-col">
+                          {(val as ContactInfo[])
+                            .map((v) =>
+                              v.value ? `${v.value}${v.comment ? `（${v.comment}）` : ''}` : '',
+                            )
+                            .filter((v) => v)
+                            .map((v, i) => (
+                              <div key={i}>{v}</div>
+                            ))}
+                        </div>
+                      ) : col.key === 'remarks' && typeof val === 'string' ? (
+                        (() => {
+                          const lines = val.split('\n');
+                          const display = lines.slice(0, 3);
+                          const truncated = lines.length > 3;
+                          return (
+                            <div className="flex flex-col tooltip-container" data-tooltip={val}>
+                              {display.map((l, i) => (
+                                <div key={i}>{l}</div>
                               ))}
-                              {showFunctionRemarks && fEntry.remarks && (
-                                (() => {
-                                  const lines = fEntry.remarks.split('\n');
-                                  const display = lines.slice(0, 2);
-                                  const truncated = lines.length > 2;
-                                  return (
-                                    <>
-                                      {display.map((l, i) => (
-                                        <div key={i}>{l}</div>
-                                      ))}
-                                      {truncated && <div>...</div>}
-                                    </>
-                                  );
-                                })()
-                              )}
+                              {truncated && <div>...</div>}
                             </div>
-                          ) : (
-                            '-'
-                          )}
-                        </td>
-                      );
-                    } else {
-                      const val = (facility as unknown as Record<string, unknown>)[col.key];
-                      return (
-                        <td
-                          key={col.key}
-                          className="py-2 px-4 border whitespace-nowrap"
-                          onContextMenu={(e) => handleFacilityCellRightClick(e, facility)}
-                        >
-                          {Array.isArray(val) ? (
-                            <div className="flex flex-col">
-                              {(val as ContactInfo[])
-                                .map((v) =>
-                                  v.value ? `${v.value}${v.comment ? `（${v.comment}）` : ''}` : ''
-                                )
-                                .filter((v) => v)
-                                .map((v, i) => (
-                                  <div key={i}>{v}</div>
-                                ))}
-                            </div>
-                          ) : col.key === 'remarks' && typeof val === 'string' ? (
-                            (() => {
-                              const lines = val.split('\n');
-                              const display = lines.slice(0, 3);
-                              const truncated = lines.length > 3;
-                              return (
-                                <div
-                                  className="flex flex-col tooltip-container"
-                                  data-tooltip={val}
-                                >
-                                  {display.map((l, i) => (
-                                    <div key={i}>{l}</div>
-                                  ))}
-                                  {truncated && <div>...</div>}
-                                </div>
-                              );
-                            })()
-                          ) : (
-                            (val as React.ReactNode) || '-'
-                          )}
-                        </td>
-                      ) as React.ReactNode;
-                    }
-                  });
+                          );
+                        })()
+                      ) : (
+                        (val as React.ReactNode) || '-'
+                      )}
+                    </td>
+                  );
                 })}
               </tr>
             ))}

--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -166,7 +166,7 @@ export default function MemoApp({ facilityId, facilityName, initialSelectedId }:
   const selected = memos.find((m) => m.id === selectedId) || null;
 
   const handleCreate = () => {
-    const memo: MemoItem = { id: 0, title: '', content: '', tag_ids: [] };
+    const memo: MemoItem = { id: 0, title: '', content: '', tag_ids: [], sort_order: memos.length + 1 };
     setEditing(memo);
     setEditingReadOnly(false);
     setEditingMessage(null);


### PR DESCRIPTION
## Summary
- merge main branch to get latest row-selection features
- keep sticky left column logic using `STICKY_GROUP_ID` and dynamic offsets
- preserve memo creation order by including `sort_order`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f3d83e8b8832886154d35eac1f584