### PR TITLE
Add hierarchical memo tree view

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import BYTEA, UUID as PG_UUID
 import uuid
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 from .database import Base
 
 
@@ -110,6 +110,7 @@ class FacilityMemo(Base):
 
     id = Column(Integer, primary_key=True)
     facility_id = Column(Integer, ForeignKey("medical_facility.id"), nullable=True)
+    parent_id = Column(Integer, ForeignKey("facility_memos.id"), nullable=True)
     title = Column(Text, nullable=False)
     content = Column(Text)
     is_deleted = Column(Boolean, default=False)
@@ -132,6 +133,11 @@ class FacilityMemo(Base):
         "FacilityMemoLock",
         uselist=False,
         back_populates="memo",
+        cascade="all, delete-orphan",
+    )
+    children = relationship(
+        "FacilityMemo",
+        backref=backref("parent", remote_side=[id]),
         cascade="all, delete-orphan",
     )
 

--- a/backend/app/routers/memo.py
+++ b/backend/app/routers/memo.py
@@ -53,6 +53,7 @@ def create_memo(
     next_order = (max_order[0] + 1) if max_order else 1
     db_memo = models.FacilityMemo(
         facility_id=facility_id,
+        parent_id=memo.parent_id,
         title=memo.title,
         content=memo.content,
         sort_order=next_order,
@@ -95,6 +96,7 @@ def create_general_memo(
     next_order = (max_order[0] + 1) if max_order else 1
     db_memo = models.FacilityMemo(
         facility_id=None,
+        parent_id=memo.parent_id,
         title=memo.title,
         content=memo.content,
         sort_order=next_order,
@@ -166,6 +168,8 @@ def update_memo(
         db_memo.sort_order = update.sort_order
     if update.facility_id is not None:
         db_memo.facility_id = update.facility_id
+    if update.parent_id is not None:
+        db_memo.parent_id = update.parent_id
     if update.tag_ids is not None:
         db.query(models.FacilityMemoTagLink).filter(
             models.FacilityMemoTagLink.memo_id == memo_id
@@ -369,7 +373,7 @@ def unlock_memo(memo_id: int, user: str, db: Session = Depends(get_db)):
 def reorder_memos(update: schemas.MemoOrderUpdate, db: Session = Depends(get_db)):
     for item in update.orders:
         db.query(models.FacilityMemo).filter(models.FacilityMemo.id == item.id).update(
-            {"sort_order": item.sort_order}
+            {"sort_order": item.sort_order, "parent_id": item.parent_id}
         )
     db.commit()
     return {"message": "ok"}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -194,6 +194,7 @@ class MemoTagCreate(BaseModel):
 class FacilityMemoBase(BaseModel):
     id: int
     facility_id: Optional[int]
+    parent_id: Optional[int]
     title: str
     content: Optional[str]
     is_deleted: bool
@@ -210,6 +211,7 @@ class FacilityMemoCreate(BaseModel):
     content: Optional[str] = None
     tag_ids: Optional[List[int]] = None
     facility_id: Optional[int] = None
+    parent_id: Optional[int] = None
     sort_order: Optional[int] = None
 
     @validator("title")
@@ -224,6 +226,7 @@ class FacilityMemoUpdate(BaseModel):
     content: Optional[str] = None
     tag_ids: Optional[List[int]] = None
     facility_id: Optional[int] = None
+    parent_id: Optional[int] = None
     sort_order: Optional[int] = None
 
 
@@ -253,6 +256,7 @@ class FacilityMemoLockBase(BaseModel):
 class MemoOrderItem(BaseModel):
     id: int
     sort_order: int
+    parent_id: Optional[int] = None
 
 
 class MemoOrderUpdate(BaseModel):

--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -9,12 +9,14 @@ import ImageModal from '../components/ImageModal';
 interface Props {
   memo: MemoItem | null;
   tagOptions: MemoTag[];
+  childMemos?: MemoItem[];
   onEdit: () => void;
   onToggleDelete: () => void;
   onShowHistory: () => void;
+  onSelectMemo?: (id: number) => void;
 }
 
-export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, onShowHistory }: Props) {
+export default function MemoViewer({ memo, tagOptions, childMemos = [], onEdit, onToggleDelete, onShowHistory, onSelectMemo }: Props) {
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const [imageAlt, setImageAlt] = useState<string>('');
   if (!memo) return <div className="flex-1 p-4">メモを選択してください</div>;
@@ -113,6 +115,22 @@ export default function MemoViewer({ memo, tagOptions, onEdit, onToggleDelete, o
           />
         )}
       </div>
+      {childMemos.length > 0 && (
+        <div className="mt-4">
+          <h2 className="text-lg font-bold">目次</h2>
+          <ul className="list-disc ml-5">
+            {childMemos.map((c) => (
+              <li
+                key={c.id}
+                className="text-blue-600 cursor-pointer"
+                onClick={() => onSelectMemo && onSelectMemo(c.id)}
+              >
+                {c.title}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       {tagObjs.length > 0 && (
         <div className="mt-2 text-sm flex flex-wrap gap-1">
           {tagObjs.map((t) => (


### PR DESCRIPTION
## Summary
- support parent-child memos on the backend
- update schema and reorder endpoint for hierarchy
- add memo tree list with drag-and-drop
- show child memo TOC in viewer

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68830d0738cc83288f031625a9f7c42d