### PR TITLE
Fix memo child selection

### DIFF
--- a/my-medical-app/src/memo/MemoList.tsx
+++ b/my-medical-app/src/memo/MemoList.tsx
@@ -197,7 +197,10 @@ function MemoNode({ node, depth, selectedId, onSelect, onDrop, expanded, toggle 
       onDragStart={handleDragStart}
       onDrop={handleDropNode}
       onDragOver={handleDragOver}
-      onClick={() => onSelect(node.id)}
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect(node.id);
+      }}
     >
       <div className="flex items-center">
         {node.children.length > 0 && (


### PR DESCRIPTION
## Summary
- fix MemoList so clicking a child memo selects that child
- run frontend lint and build

## Testing
- `npm run lint` in `my-medical-app`
- `npm run build` in `my-medical-app`


------
https://chatgpt.com/codex/tasks/task_e_68831a75ec9083289c056a4bc766545b