### PR TITLE
Fix memo search filtering

### DIFF
--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -163,7 +163,7 @@ export default function MemoApp({ facilityId, facilityName, initialSelectedId }:
   });
 
   const visibleIds = new Set(filtered.map((m) => m.id));
-  memos.forEach((m) => {
+  filtered.forEach((m) => {
     let p = m.parent_id;
     while (p) {
       if (visibleIds.has(p)) break;


### PR DESCRIPTION
## Summary
- fix logic so memo search doesn't show unrelated child pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68833cfc85c483288487649241c3b3a3