### PR TITLE
Implement template ordering

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from .routers import (
     facility_function_entry,
     function_category,
     memo,
+    memo_template,
     memo_tag,
     note_image,
 )
@@ -31,5 +32,6 @@ app.include_router(function.router)
 app.include_router(facility_function_entry.router)
 app.include_router(function_category.router)
 app.include_router(memo.router)
+app.include_router(memo_template.router)
 app.include_router(memo_tag.router)
 app.include_router(note_image.router)

--- a/backend/app/routers/memo_template.py
+++ b/backend/app/routers/memo_template.py
@@ -1,0 +1,296 @@
+from typing import List, Optional
+from datetime import datetime, timedelta, timezone
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+from .. import database, models, schemas
+
+router = APIRouter(prefix="/memo-templates", tags=["memo-templates"])
+
+
+def get_db():
+    db = database.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("", response_model=List[schemas.MemoTemplateBase])
+def list_templates(
+    include_deleted: bool = False,
+    search: Optional[str] = None,
+    tag: Optional[List[int]] = None,
+    db: Session = Depends(get_db),
+):
+    query = db.query(models.MemoTemplate)
+    if not include_deleted:
+        query = query.filter(models.MemoTemplate.is_deleted == False)
+    if search:
+        ilike = f"%{search}%"
+        query = query.filter(
+            models.MemoTemplate.title.ilike(ilike)
+            | models.MemoTemplate.name.ilike(ilike)
+            | models.MemoTemplate.content.ilike(ilike)
+        )
+    if tag:
+        query = query.join(models.MemoTemplateTagLink).filter(
+            models.MemoTemplateTagLink.tag_id.in_(tag)
+        )
+    return query.order_by(models.MemoTemplate.sort_order.asc()).all()
+
+
+@router.post("", response_model=schemas.MemoTemplateBase)
+def create_template(
+    tpl: schemas.MemoTemplateCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    max_order = db.query(models.MemoTemplate.sort_order).order_by(models.MemoTemplate.sort_order.desc()).first()
+    next_order = (max_order[0] + 1) if max_order else 1
+    obj = models.MemoTemplate(
+        name=tpl.name,
+        title=tpl.title,
+        content=tpl.content,
+        sort_order=tpl.sort_order or next_order,
+    )
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    for tag_id in tpl.tag_ids or []:
+        db.add(models.MemoTemplateTagLink(template_id=obj.id, tag_id=tag_id))
+    db.commit()
+    db.refresh(obj)
+    ip = request.headers.get("X-Forwarded-For") or request.client.host
+    db.add(
+        models.MemoTemplateVersion(
+            template_id=obj.id,
+            version_no=1,
+            content=obj.content,
+            ip_address=ip,
+            action="create",
+        )
+    )
+    db.commit()
+    return obj
+
+
+@router.put("/{tpl_id}", response_model=schemas.MemoTemplateBase)
+def update_template(
+    tpl_id: int,
+    update: schemas.MemoTemplateUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    obj = db.query(models.MemoTemplate).filter(models.MemoTemplate.id == tpl_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Template not found")
+    if update.content is not None and update.content != obj.content:
+        last = (
+            db.query(models.MemoTemplateVersion)
+            .filter(models.MemoTemplateVersion.template_id == tpl_id)
+            .order_by(models.MemoTemplateVersion.version_no.desc())
+            .first()
+        )
+        next_no = last.version_no + 1 if last else 1
+        ip = request.headers.get("X-Forwarded-For") or request.client.host
+        db.add(
+            models.MemoTemplateVersion(
+                template_id=tpl_id,
+                version_no=next_no,
+                content=obj.content,
+                ip_address=ip,
+                action="edit",
+            )
+        )
+        obj.content = update.content
+    if update.name is not None:
+        obj.name = update.name
+    if update.title is not None:
+        obj.title = update.title
+    if update.sort_order is not None:
+        obj.sort_order = update.sort_order
+    if update.tag_ids is not None:
+        db.query(models.MemoTemplateTagLink).filter(
+            models.MemoTemplateTagLink.template_id == tpl_id
+        ).delete()
+        for tid in update.tag_ids:
+            db.add(models.MemoTemplateTagLink(template_id=tpl_id, tag_id=tid))
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.delete("/{tpl_id}", response_model=dict)
+def delete_template(tpl_id: int, request: Request, db: Session = Depends(get_db)):
+    obj = db.query(models.MemoTemplate).filter(models.MemoTemplate.id == tpl_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Template not found")
+    obj.is_deleted = True
+    last = (
+        db.query(models.MemoTemplateVersion)
+        .filter(models.MemoTemplateVersion.template_id == tpl_id)
+        .order_by(models.MemoTemplateVersion.version_no.desc())
+        .first()
+    )
+    next_no = last.version_no + 1 if last else 1
+    ip = request.headers.get("X-Forwarded-For") or request.client.host
+    db.add(
+        models.MemoTemplateVersion(
+            template_id=tpl_id,
+            version_no=next_no,
+            content=obj.content,
+            ip_address=ip,
+            action="delete",
+        )
+    )
+    db.commit()
+    return {"message": "deleted"}
+
+
+@router.put("/{tpl_id}/restore", response_model=schemas.MemoTemplateBase)
+def restore_template(tpl_id: int, request: Request, db: Session = Depends(get_db)):
+    obj = (
+        db.query(models.MemoTemplate)
+        .filter(models.MemoTemplate.id == tpl_id, models.MemoTemplate.is_deleted == True)
+        .first()
+    )
+    if not obj:
+        raise HTTPException(status_code=404, detail="Template not found")
+    obj.is_deleted = False
+    last = (
+        db.query(models.MemoTemplateVersion)
+        .filter(models.MemoTemplateVersion.template_id == tpl_id)
+        .order_by(models.MemoTemplateVersion.version_no.desc())
+        .first()
+    )
+    next_no = last.version_no + 1 if last else 1
+    ip = request.headers.get("X-Forwarded-For") or request.client.host
+    db.add(
+        models.MemoTemplateVersion(
+            template_id=tpl_id,
+            version_no=next_no,
+            content=obj.content,
+            ip_address=ip,
+            action="restore",
+        )
+    )
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+@router.get("/{tpl_id}/versions", response_model=List[schemas.MemoTemplateVersionBase])
+def get_versions(
+    tpl_id: int,
+    db: Session = Depends(get_db),
+):
+    return (
+        db.query(models.MemoTemplateVersion)
+        .filter(models.MemoTemplateVersion.template_id == tpl_id)
+        .order_by(models.MemoTemplateVersion.version_no.desc())
+        .all()
+    )
+
+
+@router.post("/{tpl_id}/versions/{version_no}/restore", response_model=schemas.MemoTemplateBase)
+def restore_version(
+    tpl_id: int,
+    version_no: int,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    obj = db.query(models.MemoTemplate).filter(models.MemoTemplate.id == tpl_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Template not found")
+    ver = (
+        db.query(models.MemoTemplateVersion)
+        .filter(
+            models.MemoTemplateVersion.template_id == tpl_id,
+            models.MemoTemplateVersion.version_no == version_no,
+        )
+        .first()
+    )
+    if not ver:
+        raise HTTPException(status_code=404, detail="Version not found")
+    last = (
+        db.query(models.MemoTemplateVersion)
+        .filter(models.MemoTemplateVersion.template_id == tpl_id)
+        .order_by(models.MemoTemplateVersion.version_no.desc())
+        .first()
+    )
+    next_no = last.version_no + 1 if last else 1
+    ip = request.headers.get("X-Forwarded-For") or request.client.host
+    db.add(
+        models.MemoTemplateVersion(
+            template_id=tpl_id,
+            version_no=next_no,
+            content=obj.content,
+            ip_address=ip,
+            action="restore",
+        )
+    )
+    obj.content = ver.content
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+LOCK_TIMEOUT = timedelta(minutes=5)
+
+
+@router.get("/{tpl_id}/lock", response_model=Optional[schemas.MemoTemplateLockBase])
+def get_lock(tpl_id: int, db: Session = Depends(get_db)):
+    return (
+        db.query(models.MemoTemplateLock)
+        .filter(models.MemoTemplateLock.template_id == tpl_id)
+        .first()
+    )
+
+
+@router.post("/{tpl_id}/lock", response_model=schemas.MemoTemplateLockBase)
+def lock_template(tpl_id: int, user: str, request: Request, db: Session = Depends(get_db)):
+    now = datetime.now(timezone.utc)
+    ip = request.headers.get("X-Forwarded-For") or request.client.host
+    lock = (
+        db.query(models.MemoTemplateLock)
+        .filter(models.MemoTemplateLock.template_id == tpl_id)
+        .first()
+    )
+    if lock and lock.locked_by != user and lock.locked_at and lock.locked_at > now - LOCK_TIMEOUT:
+        raise HTTPException(status_code=409, detail=f"locked by {lock.locked_by} ({lock.ip_address})")
+    if not lock:
+        lock = models.MemoTemplateLock(
+            template_id=tpl_id,
+            locked_by=user,
+            locked_at=now,
+            ip_address=ip,
+        )
+        db.add(lock)
+    else:
+        lock.locked_by = user
+        lock.locked_at = now
+        lock.ip_address = ip
+    db.commit()
+    db.refresh(lock)
+    return lock
+
+
+@router.delete("/{tpl_id}/lock", response_model=dict)
+def unlock_template(tpl_id: int, user: str, db: Session = Depends(get_db)):
+    lock = (
+        db.query(models.MemoTemplateLock)
+        .filter(models.MemoTemplateLock.template_id == tpl_id)
+        .first()
+    )
+    if lock and lock.locked_by == user:
+        db.delete(lock)
+        db.commit()
+    return {"message": "unlocked"}
+
+
+@router.post("/reorder", response_model=dict)
+def reorder_templates(update: schemas.MemoTemplateOrderUpdate, db: Session = Depends(get_db)):
+    for item in update.orders:
+        db.query(models.MemoTemplate).filter(models.MemoTemplate.id == item.id).update({"sort_order": item.sort_order})
+    db.commit()
+    return {"message": "ok"}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -280,3 +280,77 @@ class NoteImageCreate(BaseModel):
     file_name: str
     mime_type: str
 
+
+class MemoTemplateBase(BaseModel):
+    id: int
+    name: str
+    title: str
+    content: Optional[str]
+    is_deleted: bool
+    updated_at: Optional[datetime]
+    sort_order: int
+    tags: List[MemoTagBase] = []
+
+    class Config:
+        from_attributes = True
+
+
+class MemoTemplateCreate(BaseModel):
+    name: str
+    title: str
+    content: Optional[str] = None
+    tag_ids: Optional[List[int]] = None
+    sort_order: Optional[int] = None
+
+    @validator("name")
+    def validate_name(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("テンプレート名が未入力のため登録できません")
+        return v
+
+    @validator("title")
+    def validate_title(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("タイトルが未入力のため登録できません")
+        return v
+
+
+class MemoTemplateUpdate(BaseModel):
+    name: Optional[str] = None
+    title: Optional[str] = None
+    content: Optional[str] = None
+    tag_ids: Optional[List[int]] = None
+    sort_order: Optional[int] = None
+
+
+class MemoTemplateVersionBase(BaseModel):
+    id: int
+    template_id: int
+    version_no: int
+    content: Optional[str]
+    created_at: Optional[datetime]
+    ip_address: Optional[str]
+    action: Optional[str]
+
+    class Config:
+        from_attributes = True
+
+
+class MemoTemplateLockBase(BaseModel):
+    template_id: int
+    locked_by: Optional[str]
+    locked_at: Optional[datetime]
+    ip_address: Optional[str]
+
+    class Config:
+        from_attributes = True
+
+
+class MemoTemplateOrderItem(BaseModel):
+    id: int
+    sort_order: int
+
+
+class MemoTemplateOrderUpdate(BaseModel):
+    orders: List[MemoTemplateOrderItem]
+

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -51,15 +51,18 @@ CREATE TABLE memo_tags (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
     remark TEXT,
+    color TEXT,
     is_deleted BOOLEAN DEFAULT FALSE
 );
 
 CREATE TABLE facility_memos (
     id SERIAL PRIMARY KEY,
     facility_id INTEGER REFERENCES medical_facility(id),
+    parent_id INTEGER REFERENCES facility_memos(id),
     title TEXT NOT NULL,
     content TEXT,
     is_deleted BOOLEAN DEFAULT FALSE,
+    sort_order INTEGER DEFAULT 0,
     updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -94,4 +97,40 @@ CREATE TABLE note_images (
     mime_type TEXT NOT NULL,
     data BYTEA NOT NULL,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Template feature tables
+
+CREATE TABLE memo_templates (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT,
+    is_deleted BOOLEAN DEFAULT FALSE,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    sort_order INTEGER DEFAULT 0
+);
+
+CREATE TABLE memo_template_versions (
+    id SERIAL PRIMARY KEY,
+    template_id INTEGER REFERENCES memo_templates(id) ON DELETE CASCADE,
+    version_no INTEGER NOT NULL,
+    content TEXT,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    ip_address TEXT,
+    action TEXT,
+    UNIQUE (template_id, version_no)
+);
+
+CREATE TABLE memo_template_tag_links (
+    template_id INTEGER REFERENCES memo_templates(id) ON DELETE CASCADE,
+    tag_id INTEGER REFERENCES memo_tags(id),
+    PRIMARY KEY (template_id, tag_id)
+);
+
+CREATE TABLE memo_template_locks (
+    template_id INTEGER PRIMARY KEY REFERENCES memo_templates(id) ON DELETE CASCADE,
+    locked_by TEXT,
+    locked_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    ip_address TEXT
 );

--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -5,6 +5,7 @@ import MemoEditor from './MemoEditor';
 import VerticalSplit from '../components/VerticalSplit';
 import MemoTagManagerModal from './MemoTagManagerModal';
 import MemoHistoryModal from './MemoHistoryModal';
+import TemplateSelectModal from './TemplateSelectModal';
 
 export interface MemoItem {
   id: number;
@@ -78,6 +79,7 @@ export default function MemoApp({ facilityId, facilityName, initialSelectedId }:
   const [search, setSearch] = useState('');
   const [tagFilter, setTagFilter] = useState<number[]>([]);
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+  const [isTemplateOpen, setIsTemplateOpen] = useState(false);
 
   useEffect(() => {
     if (initialSelectedId) {
@@ -318,6 +320,7 @@ export default function MemoApp({ facilityId, facilityName, initialSelectedId }:
             setEditingMessage(null);
           }}
           onOpenTagMaster={() => setIsTagMasterOpen(true)}
+          onOpenTemplateSelect={() => setIsTemplateOpen(true)}
           readOnly={editingReadOnly}
           message={editingMessage || undefined}
         />
@@ -329,6 +332,17 @@ export default function MemoApp({ facilityId, facilityName, initialSelectedId }:
           fetchTags();
         }}
       />
+      {editing && (
+        <TemplateSelectModal
+          isOpen={isTemplateOpen}
+          tagOptions={tagMaster}
+          onClose={() => setIsTemplateOpen(false)}
+          onSelect={(tpl) => {
+            setEditing((prev) => prev && { ...prev, title: tpl.title, content: tpl.content, tag_ids: tpl.tag_ids });
+            setIsTemplateOpen(false);
+          }}
+        />
+      )}
       {selected && (
         <MemoHistoryModal
           memoId={selected.id}

--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -16,11 +16,12 @@ interface Props {
   onSave: (m: MemoItem) => void;
   onCancel: () => void;
   onOpenTagMaster: () => void;
+  onOpenTemplateSelect: () => void;
   readOnly?: boolean;
   message?: string;
 }
 
-export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenTagMaster, readOnly = false, message }: Props) {
+export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenTagMaster, onOpenTemplateSelect, readOnly = false, message }: Props) {
   const [title, setTitle] = useState(memo.title);
   const [content, setContent] = useState(memo.content);
   const [tags, setTags] = useState<number[]>(memo.tag_ids);
@@ -308,13 +309,22 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
             />
             <div className="border p-1 mt-2 space-y-1 relative pr-20">
               {!readOnly && (
-                <button
-                  type="button"
-                  className="absolute top-1 right-1 bg-blue-500 text-white text-xs px-2 py-1 rounded"
-                  onClick={onOpenTagMaster}
-                >
-                  タグ管理
-                </button>
+                <div className="absolute top-1 right-1 flex gap-1">
+                  <button
+                    type="button"
+                    className="bg-blue-500 text-white text-xs px-2 py-1 rounded"
+                    onClick={onOpenTemplateSelect}
+                  >
+                    テンプレ
+                  </button>
+                  <button
+                    type="button"
+                    className="bg-blue-500 text-white text-xs px-2 py-1 rounded"
+                    onClick={onOpenTagMaster}
+                  >
+                    タグ管理
+                  </button>
+                </div>
               )}
               <TagSearchInput
                 options={options}

--- a/my-medical-app/src/memo/TemplateSelectModal.tsx
+++ b/my-medical-app/src/memo/TemplateSelectModal.tsx
@@ -1,0 +1,107 @@
+import { Dialog, Transition } from '@headlessui/react';
+import { Fragment, useEffect, useState } from 'react';
+import ImeInput from '../components/ImeInput';
+import TagSearchInput, { Option } from '../components/TagSearchInput';
+import type { MemoTag } from './MemoApp';
+
+interface Template {
+  id: number;
+  name: string;
+  title: string;
+  content: string | null;
+  updated_at: string;
+  tag_ids: number[];
+  sort_order: number;
+}
+
+interface Props {
+  isOpen: boolean;
+  tagOptions: MemoTag[];
+  onSelect: (t: Template) => void;
+  onClose: () => void;
+}
+
+const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:8001';
+
+export default function TemplateSelectModal({ isOpen, tagOptions, onSelect, onClose }: Props) {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [search, setSearch] = useState('');
+  const [tagFilter, setTagFilter] = useState<number[]>([]);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  const options: Option[] = tagOptions.map((t) => ({ value: t.id, label: t.name, color: t.color }));
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const params = new URLSearchParams();
+    if (search) params.append('search', search);
+    tagFilter.forEach((t) => params.append('tag', String(t)));
+    fetch(`${apiBase}/memo-templates?${params.toString()}`)
+      .then((res) => res.json())
+      .then((data: Template[]) => {
+        data.sort((a, b) => a.sort_order - b.sort_order);
+        setTemplates(data);
+      });
+  }, [isOpen, search, tagFilter]);
+
+  const reorder = (list: Template[]) => {
+    setTemplates(list);
+    const orders = list.map((t, i) => ({ id: t.id, sort_order: i + 1 }));
+    fetch(`${apiBase}/memo-templates/reorder`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orders }),
+    });
+  };
+
+  const handleDrop = (index: number) => {
+    if (dragIndex === null) return;
+    const newList = [...templates];
+    const [moved] = newList.splice(dragIndex, 1);
+    newList.splice(index, 0, moved);
+    reorder(newList);
+    setDragIndex(null);
+  };
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-[70]" onClose={onClose}>
+        <div className="fixed inset-0 bg-black bg-opacity-25" />
+        <div className="fixed inset-0 overflow-y-auto flex items-center justify-center p-4">
+          <Dialog.Panel className="w-full max-w-2xl bg-white rounded p-4 shadow">
+            <Dialog.Title className="text-lg font-bold mb-2">テンプレート選択</Dialog.Title>
+            <div className="flex gap-2 mb-2">
+              <ImeInput value={search} onChange={(e) => setSearch(e.target.value)} className="border p-1 flex-1" placeholder="検索" />
+              <TagSearchInput options={options} selected={tagFilter} onChange={setTagFilter} className="flex-1" />
+            </div>
+            <ul className="max-h-80 overflow-y-auto space-y-2">
+              {templates.map((t, idx) => (
+                <li
+                  key={t.id}
+                  className="border p-2 flex justify-between items-center cursor-move"
+                  draggable
+                  onDragStart={() => setDragIndex(idx)}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={() => handleDrop(idx)}
+                >
+                  <div>
+                    <div className="font-bold">{t.name}</div>
+                    <div className="text-sm text-gray-600">{new Date(t.updated_at).toLocaleString()}</div>
+                  </div>
+                  <button className="px-2 py-1 bg-blue-500 text-white text-sm rounded" onClick={() => onSelect(t)}>
+                    選択
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-end mt-4">
+              <button className="px-4 py-2 bg-gray-500 text-white rounded" onClick={onClose}>
+                閉じる
+              </button>
+            </div>
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}


### PR DESCRIPTION
## Summary
- add `sort_order` column to `MemoTemplate` model
- expose reorder API for memo templates
- include sort order fields in template schemas
- enable drag-and-drop reordering in `TemplateSelectModal`
- fix duplicate sort_order column in `FacilityMemo`
- add schema SQL for memo templates

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68833d2b3bf48328adb19d8d941c7dab