### PR TITLE
Fix pydantic configuration warning

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -272,7 +272,6 @@ class NoteImageBase(BaseModel):
 
     class Config:
         from_attributes = True
-        orm_mode = True
 
 
 class NoteImageCreate(BaseModel):
@@ -353,4 +352,3 @@ class MemoTemplateOrderItem(BaseModel):
 
 class MemoTemplateOrderUpdate(BaseModel):
     orders: List[MemoTemplateOrderItem]
-


### PR DESCRIPTION
## Summary
- remove deprecated `orm_mode` field from `NoteImageBase` schema

## Testing
- `black --check backend/app/schemas.py`


------
https://chatgpt.com/codex/tasks/task_e_68834514191c832888253b4936e88e42