### PR TITLE
Fix memo management build

### DIFF
--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -338,7 +338,15 @@ export default function MemoApp({ facilityId, facilityName, initialSelectedId }:
           tagOptions={tagMaster}
           onClose={() => setIsTemplateOpen(false)}
           onSelect={(tpl) => {
-            setEditing((prev) => prev && { ...prev, title: tpl.title, content: tpl.content, tag_ids: tpl.tag_ids });
+            setEditing(
+              (prev) =>
+                prev && {
+                  ...prev,
+                  title: tpl.title,
+                  content: tpl.content || '',
+                  tag_ids: tpl.tag_ids,
+                },
+            );
             setIsTemplateOpen(false);
           }}
         />

--- a/my-medical-app/src/memo/TemplateSelectModal.tsx
+++ b/my-medical-app/src/memo/TemplateSelectModal.tsx
@@ -1,7 +1,8 @@
 import { Dialog, Transition } from '@headlessui/react';
 import { Fragment, useEffect, useState } from 'react';
 import ImeInput from '../components/ImeInput';
-import TagSearchInput, { Option } from '../components/TagSearchInput';
+import TagSearchInput from '../components/TagSearchInput';
+import type { Option } from '../components/TagSearchInput';
 import type { MemoTag } from './MemoApp';
 
 interface Template {


### PR DESCRIPTION
## Summary
- fix TypeScript import with type-only for TemplateSelectModal
- ensure template content defaults to empty string when applied
- re-run build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688347527c988328b8bc0e54d5b4b5c4