### PR TITLE
Handle empty template name

### DIFF
--- a/my-medical-app/src/memo/MemoEditor.tsx
+++ b/my-medical-app/src/memo/MemoEditor.tsx
@@ -208,7 +208,7 @@ export default function MemoEditor({ memo, tagOptions, onSave, onCancel, onOpenT
                   onClick={() =>
                     setTemplateEdit({
                       id: 0,
-                      name: title,
+                      name: '',
                       title,
                       content,
                       tag_ids: tags,

--- a/my-medical-app/src/memo/TemplateEditModal.tsx
+++ b/my-medical-app/src/memo/TemplateEditModal.tsx
@@ -31,7 +31,7 @@ export default function TemplateEditModal({
   onSave,
   onClose,
 }: Props) {
-  const [name, setName] = useState(template.name);
+  const [name, setName] = useState(template.id ? template.name : '');
   const [title, setTitle] = useState(template.title);
   const [content, setContent] = useState(template.content || '');
   const [tags, setTags] = useState<number[]>(template.tag_ids);
@@ -41,10 +41,11 @@ export default function TemplateEditModal({
   const handleSubmit = () => {
     const method = template.id ? 'PUT' : 'POST';
     const url = template.id ? `${apiBase}/memo-templates/${template.id}` : `${apiBase}/memo-templates`;
+    const nameToSend = name.trim() ? name : title;
     fetch(url, {
       method,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, title, content, tag_ids: tags }),
+      body: JSON.stringify({ name: nameToSend, title, content, tag_ids: tags }),
     })
       .then((res) => res.json())
       .then((data: TemplateData) => {

--- a/my-medical-app/src/memo/TemplateSelectModal.tsx
+++ b/my-medical-app/src/memo/TemplateSelectModal.tsx
@@ -108,7 +108,7 @@ export default function TemplateSelectModal({ isOpen, tagOptions, onSelect, onCl
                     <button className="px-2 py-1 bg-green-500 text-white text-sm rounded" onClick={() => setEditing(t)}>
                       編集
                     </button>
-                    <button className="px-2 py-1 bg-gray-500 text-white text-sm rounded" onClick={() => setEditing({ ...t, id: 0 })}>
+                    <button className="px-2 py-1 bg-gray-500 text-white text-sm rounded" onClick={() => setEditing({ ...t, id: 0, name: '' })}>
                       複製
                     </button>
                     <button className="px-2 py-1 bg-red-500 text-white text-sm rounded" onClick={() => handleDelete(t)}>


### PR DESCRIPTION
## Summary
- initialize new template name as blank
- when saving, if the name is blank then use the title
- keep duplicate template creation consistent with this change

## Testing
- `npm run lint`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688732f0c9388328b7e3dcd43393cd13