### PR TITLE
Expand memo search to memo content

### DIFF
--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -159,7 +159,7 @@ export default function MemoApp({ facilityId, facilityName, initialSelectedId }:
 
   const filtered = memos.filter((m) => {
     if (!showDeleted && m.deleted) return false;
-    if (search && !m.title.includes(search)) return false;
+    if (search && !(m.title.includes(search) || m.content.includes(search))) return false;
     if (tagFilter.length && !tagFilter.every((t) => m.tag_ids.includes(t))) return false;
     return true;
   });

--- a/my-medical-app/src/memo/MemoList.tsx
+++ b/my-medical-app/src/memo/MemoList.tsx
@@ -195,7 +195,7 @@ export default function MemoList({
           type="text"
           value={search}
           onChange={(e) => onSearch(e.target.value)}
-          placeholder="タイトル検索"
+          placeholder="タイトル・内容検索"
           className="border p-1 flex-1 mr-2"
         />
         <label className="flex items-center text-sm">


### PR DESCRIPTION
## Summary
- search memos by both title and content
- update memo search placeholder to reflect title and content

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b0ede119483288b09213df99380fc