### PR TITLE
Ensure deleted facilities show restore action

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -83,6 +83,7 @@ class MedicalFacilityBase(BaseModel):
 
 class MedicalFacility(MedicalFacilityBase):
     id: int
+    is_deleted: bool
     functions: List[FacilityFunctionEntryBase] = []
 
     class Config:

--- a/my-medical-app/src/App.tsx
+++ b/my-medical-app/src/App.tsx
@@ -90,7 +90,7 @@ interface Facility {
   emails: ContactInfo[];
   fax?: string;
   remarks?: string;
-  is_deleted?: boolean;
+  is_deleted: boolean;
   functions: FacilityFunctionEntry[];
 }
 
@@ -275,7 +275,7 @@ export default function App() {
     emails: Array.isArray(f.emails) ? f.emails : [],
     fax: f.fax || '',
     remarks: f.remarks || '',
-    is_deleted: f.is_deleted || false,
+    is_deleted: f.is_deleted ?? false,
   });
 
   const fetchFacilities = () =>
@@ -1454,6 +1454,7 @@ export default function App() {
                     emails: [],
                     fax: '',
                     remarks: '',
+                    is_deleted: false,
                     functions: [],
                   });
                   setIsFacilityModalOpen(true);


### PR DESCRIPTION
## Summary
- include `is_deleted` field in `MedicalFacility` API schema
- use facility deletion status on the frontend and add default for new facilities

## Testing
- `python -m py_compile backend/app/schemas.py`
- `cd my-medical-app && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b100a663c8328869360aac0106efa