### PR TITLE
fix: handle deleted memos in toc

### DIFF
--- a/my-medical-app/src/memo/MemoApp.tsx
+++ b/my-medical-app/src/memo/MemoApp.tsx
@@ -181,7 +181,9 @@ export default function MemoApp({ facilityId, facilityName, initialSelectedId }:
   const finalList = memos.filter((m) => visibleIds.has(m.id));
 
   const selected = memos.find((m) => m.id === selectedId) || null;
-  const childMemos = selected ? memos.filter((m) => m.parent_id === selected.id) : [];
+  const childMemos = selected
+    ? memos.filter((m) => m.parent_id === selected.id && (showDeleted || !m.deleted))
+    : [];
 
   const handleCreate = () => {
     const memo: MemoItem = {

--- a/my-medical-app/src/memo/MemoViewer.tsx
+++ b/my-medical-app/src/memo/MemoViewer.tsx
@@ -122,10 +122,11 @@ export default function MemoViewer({ memo, tagOptions, childMemos = [], onEdit, 
             {childMemos.map((c) => (
               <li
                 key={c.id}
-                className="text-blue-600 cursor-pointer"
+                className={`cursor-pointer ${c.deleted ? 'text-gray-500 line-through' : 'text-blue-600'}`}
                 onClick={() => onSelectMemo && onSelectMemo(c.id)}
               >
                 {c.title}
+                {c.deleted && ' (削除済み)'}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- hide deleted child memos from parent page TOC unless 'show deleted' is enabled
- mark deleted child memos with strikethrough when displayed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688b1e0a707c83288cfd6eb7da7716af